### PR TITLE
Ignore PyCharm & VSCode. Apply PEP8 rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,9 @@ oelint_adv.egg-info/*
 build/
 dist/
 *.pyc
+
+# PyCharm
+.idea/*
+
+# VisualStudioCode
+.vscode/*

--- a/oelint_adv/__main__.py
+++ b/oelint_adv/__main__.py
@@ -1,23 +1,27 @@
+from oelint_adv.cls_stash import Stash
+from oelint_adv.cls_rule import load_rules
 import os
 import sys
 import argparse
 import glob
 
 sys.path.append(os.path.abspath(os.path.join(__file__, "..")))
-from oelint_adv.cls_rule import load_rules
-from oelint_adv.cls_stash import Stash
+
 
 def create_argparser():
     parser = argparse.ArgumentParser(
         description='Advanced OELint - Check bitbake recipes against OECore styleguide')
-    parser.add_argument("--suppress", default=[], action="append", help="Rules to suppress")
-    parser.add_argument("--output", default=sys.stderr, help="Where to flush the findings (default: stderr)")
+    parser.add_argument("--suppress", default=[],
+                        action="append", help="Rules to suppress")
+    parser.add_argument("--output", default=sys.stderr,
+                        help="Where to flush the findings (default: stderr)")
     parser.add_argument("files", nargs='+', help="File to parse")
     return parser
 
+
 if __name__ == '__main__':
     args = create_argparser().parse_args()
-    rules = [x for x in load_rules() if str(x) not in args.suppress] 
+    rules = [x for x in load_rules() if str(x) not in args.suppress]
     print("Loaded rules: {}".format(",".join(sorted([str(x) for x in rules]))))
     stash = Stash()
     issues = []

--- a/oelint_adv/cls_item.py
+++ b/oelint_adv/cls_item.py
@@ -20,7 +20,7 @@ class Item():
 
     def IsFromAppend(self):
         return self.Origin.endswith(".bbappend")
-    
+
     def AddLink(self, _file):
         self.Links.append(_file)
         self.Links = list(set(self.Links))
@@ -48,24 +48,29 @@ class Variable(Item):
         super().__init__(origin, line, infileline, rawtext)
         self.VarName, self.SubItem = self.extract_sub(name)
         self.VarValue = value
-    
+
     def IsAppend(self):
         return any([x for x in Variable.VARIABLE_APPEND_NEEDLES if self.Raw.find(x) != -1]) or self.Raw.find("_append") != -1
-    
+
     def IsMultiLine(self):
         return "\\" in self.Raw
 
+
 class Comment(Item):
     CLASSIFIER = "Comment"
+
     def __init__(self, origin, line, infileline, rawtext):
         super().__init__(origin, line, infileline, rawtext)
+
 
 class Include(Item):
     CLASSIFIER = "Include"
     ATTR_INCNAME = "IncName"
+
     def __init__(self, origin, line, infileline, rawtext, incname):
         super().__init__(origin, line, infileline, rawtext)
         self.IncName = incname
+
 
 class Function(Item):
     ATTR_FUNCNAME = "FuncName"
@@ -74,34 +79,40 @@ class Function(Item):
 
     def __init__(self, origin, line, infileline, rawtext, name, body):
         super().__init__(origin, line, infileline, rawtext)
-        self.FuncName, self.SubItem = self.extract_sub(name[:name.find("{")].replace("(", "").replace(")", "").strip())
+        self.FuncName, self.SubItem = self.extract_sub(
+            name[:name.find("{")].replace("(", "").replace(")", "").strip())
         self.FuncBody = body
 
 
 class PythonBlock(Item):
     ATTR_FUNCNAME = "FuncName"
     CLASSIFIER = "PythonBlock"
+
     def __init__(self, origin, line, infileline, rawtext, name):
         super().__init__(origin, line, infileline, rawtext)
         self.FuncName = name
+
 
 class TaskAssignment(Item):
     ATTR_FUNCNAME = "FuncName"
     ATTR_VAR = "VarName"
     ATTR_VARVAL = "VarValue"
     CLASSIFIER = "TaskAssignment"
+
     def __init__(self, origin, line, infileline, rawtext, name, ident, value):
         super().__init__(origin, line, infileline, rawtext)
         self.FuncName = name
         self.VarName = ident
         self.VarValue = value
 
+
 class TaskAdd(Item):
     ATTR_FUNCNAME = "FuncName"
     ATTR_BEFORE = "Before"
     ATTR_AFTER = "After"
     CLASSIFIER = "TaskAdd"
-    def __init__(self, origin, line, infileline, rawtext, name, before = "", after = ""):
+
+    def __init__(self, origin, line, infileline, rawtext, name, before="", after=""):
         super().__init__(origin, line, infileline, rawtext)
         self.FuncName = name
         self.Before = [x for x in (before or "").split(" ") if x]

--- a/oelint_adv/cls_rule.py
+++ b/oelint_adv/cls_rule.py
@@ -2,12 +2,13 @@ import os
 import glob
 from oelint_adv.cls_item import *
 
+
 class Rule():
     def __init__(self, id="", severity="", message=""):
         self.ID = id
         self.Severity = severity
         self.Msg = message
-    
+
     def check(self, _file, stash):
         return []
 
@@ -23,13 +24,14 @@ class Rule():
     def OverrideMsg(self, newmsg):
         self.Msg = newmsg
 
+
 def load_rules():
     res = []
     for file in glob.glob(os.path.join(os.path.dirname(os.path.abspath(__file__)), "rule_*.py")):
         name = os.path.splitext(os.path.basename(file))[0]
-        for m in ["oelint_adv." + name]:##, "." + name, name]:
+        for m in ["oelint_adv." + name]:  # , "." + name, name]:
             try:
-                module = __import__(name)                
+                module = __import__(name)
                 for member in dir(module):
                     try:
                         if issubclass(getattr(module, member), Rule):

--- a/oelint_adv/cls_stash.py
+++ b/oelint_adv/cls_stash.py
@@ -3,6 +3,7 @@ from oelint_adv.parser import get_items
 import re
 import os
 
+
 class Stash():
 
     def __init__(self):
@@ -14,9 +15,10 @@ class Stash():
         if forcedLink:
             for item in [x for x in res if x.Origin == _file]:
                 item.AddLink(forcedLink)
-        ## Match bbappends to bbs
+        # Match bbappends to bbs
         if _file.endswith(".bbappend"):
-            bn_this = os.path.basename(_file).replace(".bbappend", "").replace("%", ".*")
+            bn_this = os.path.basename(_file).replace(
+                ".bbappend", "").replace("%", ".*")
             for item in self.__list:
                 if re.match(bn_this, os.path.basename(item.Origin).replace(".bb", "")):
                     item.AddLink(_file)
@@ -30,24 +32,25 @@ class Stash():
 
     def __is_linked_to(self, item, filename):
         return filename in item.Links or filename == item.Origin
-    
+
     def __get_items_by_file(self, items, filename):
         if not filename:
             return items
         return [x for x in items if self.__is_linked_to(x, filename)]
-    
+
     def __get_items_by_classifier(self, items, classifier):
         if not classifier:
             return items
         return [x for x in items if x.CLASSIFIER == classifier]
-    
+
     def __get_items_by_attribute(self, items, attname, attvalue):
         if not attname:
             return items
-        ## v is a list
+        # v is a list
         res = [x for x in items if attname in x.GetAttributes().keys()]
         if attvalue:
-            res = [x for x in res if (attname in x.GetAttributes().keys() and x.GetAttributes()[attname] == attvalue)]
+            res = [x for x in res if (attname in x.GetAttributes(
+            ).keys() and x.GetAttributes()[attname] == attvalue)]
         return res
 
     def GetItemsFor(self, filename=None, classifier=None, attribute=None, attributeValue=None):

--- a/oelint_adv/helper_files.py
+++ b/oelint_adv/helper_files.py
@@ -3,24 +3,29 @@ import glob
 from oelint_adv.cls_stash import Stash
 from oelint_adv.cls_item import Comment, Function, Include, Item, PythonBlock, Variable
 
+
 def get_files(stash, _file, pattern):
     res = []
-    src_uris = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER, attribute=Variable.ATTR_VAR, attributeValue="SRC_URI")
-    files_paths = list(set(["{}/*/{}".format(os.path.dirname(x.Origin), pattern) for x in src_uris]))
+    src_uris = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
+                                 attribute=Variable.ATTR_VAR, attributeValue="SRC_URI")
+    files_paths = list(
+        set(["{}/*/{}".format(os.path.dirname(x.Origin), pattern) for x in src_uris]))
     for item in src_uris:
-        files_paths += list(set(["{}/*/{}".format(os.path.dirname(x.Origin), pattern) for x in stash.GetItemsFor(filename=item.Origin)]))
+        files_paths += list(set(["{}/*/{}".format(os.path.dirname(x.Origin), pattern)
+                                 for x in stash.GetItemsFor(filename=item.Origin)]))
     for item in files_paths:
         res += glob.glob(item)
     return list(set(res))
-        
+
+
 def get_scr_components(string):
-    comp = string.replace("\t", "").strip(" \n\"").replace("://", ";", 1).split(";")
+    comp = string.replace("\t", "").strip(
+        " \n\"").replace("://", ";", 1).split(";")
     if len(comp) < 2:
-        return { "proto": "dummy", "name": "" }
-    res = { "proto": comp[0], "name": comp[1] }
+        return {"proto": "dummy", "name": ""}
+    res = {"proto": comp[0], "name": comp[1]}
     for i in range(2, len(comp)):
         sp = comp[i].split("=")
         if len(sp) > 1:
             res[sp[0]] = sp[1]
     return res
-

--- a/oelint_adv/parser.py
+++ b/oelint_adv/parser.py
@@ -3,6 +3,7 @@ import collections
 import os
 from oelint_adv.cls_item import Item, Comment, Function, PythonBlock, Variable, Include, TaskAdd, TaskAssignment
 
+
 def prepare_lines(_file, lineOffset=0):
     __func_start_regexp__ = r".*(((?P<py>python)|(?P<fr>fakeroot))\s*)*(?P<func>[\w\.\-\+\{\}\$]+)?\s*\(\s*\)\s*\{"
     with open(_file) as i:
@@ -30,16 +31,18 @@ def prepare_lines(_file, lineOffset=0):
                     _, line = _iter.__next__()
                     if not line.strip():
                         break
-            prep_lines.append({"line": num + 1 + lineOffset, "raw": raw_line , "cnt": raw_line.replace("\n", "").replace("\\", "")})
-        ##print(prep_lines)
+            prep_lines.append({"line": num + 1 + lineOffset, "raw": raw_line,
+                               "cnt": raw_line.replace("\n", "").replace("\\", "")})
+        # print(prep_lines)
         return prep_lines
     return []
+
 
 def split_filename_bb(_file):
     __regex_version = r"(?P<recipe>[A-Za-z\-0-9]+)(_(?P<version>.*))*\.(?P<suffix>.*)"
 
 
-def get_items(stash, _file, lineOffset = 0):
+def get_items(stash, _file, lineOffset=0):
     res = []
     __regex_var = r"^.*?(?P<varname>([A-Z0-9a-z_-]|\$|\{|\})+)(\s*|\t*)(\+|\?)*=(\s*|\t*)(?P<varval>.*)"
     __regex_func = r"^.*(((?P<py>python)|(?P<fr>fakeroot))\s*)*(?P<func>[\w\.\-\+\{\}\$]+)?\s*\(\s*\)\s*\{(?P<funcbody>.*)\s*\}"
@@ -70,17 +73,23 @@ def get_items(stash, _file, lineOffset = 0):
                     if any(res) and isinstance(res[-1], PythonBlock):
                         res[-1].Raw += line["raw"]
                     else:
-                        res.append(PythonBlock(_file, line["line"],  line["line"] - lineOffset, line["raw"], m.group("funcname")))
+                        res.append(PythonBlock(
+                            _file, line["line"],  line["line"] - lineOffset, line["raw"], m.group("funcname")))
                 elif k == "vars":
-                    res.append(Variable(_file, line["line"], line["line"] - lineOffset, line["raw"], m.group("varname"), m.group("varval")))
+                    res.append(Variable(
+                        _file, line["line"], line["line"] - lineOffset, line["raw"], m.group("varname"), m.group("varval")))
                 elif k == "func":
-                    res.append(Function(_file, line["line"], line["line"] - lineOffset, line["raw"], line["raw"], m.group("funcbody")))
+                    res.append(Function(
+                        _file, line["line"], line["line"] - lineOffset, line["raw"], line["raw"], m.group("funcbody")))
                 elif k == "comment":
-                    res.append(Comment(_file, line["line"], line["line"] - lineOffset, line["raw"]))
+                    res.append(
+                        Comment(_file, line["line"], line["line"] - lineOffset, line["raw"]))
                 elif k == "inherit":
-                    res.append(Variable(_file, line["line"], line["line"] - lineOffset, line["raw"], "inherit", m.group("inhname")))
+                    res.append(Variable(
+                        _file, line["line"], line["line"] - lineOffset, line["raw"], "inherit", m.group("inhname")))
                 elif k == "taskassign":
-                    res.append(TaskAssignment(_file, line["line"], line["line"] - lineOffset, line["raw"], m.group("func"), m.group("ident"), m.group("varval")))
+                    res.append(TaskAssignment(_file, line["line"], line["line"] - lineOffset, line["raw"], m.group(
+                        "func"), m.group("ident"), m.group("varval")))
                 elif k == "addtask":
                     _g = m.groupdict()
                     if "before" in _g.keys():
@@ -91,15 +100,19 @@ def get_items(stash, _file, lineOffset = 0):
                         _a = _g["after"]
                     else:
                         _a = ""
-                    res.append(TaskAdd(_file, line["line"], line["line"] - lineOffset, line["raw"], m.group("func"), _b, _a))
+                    res.append(TaskAdd(
+                        _file, line["line"], line["line"] - lineOffset, line["raw"], m.group("func"), _b, _a))
                 elif k == "include":
-                    tmp = stash.AddFile(os.path.abspath(os.path.join(os.path.dirname(_file), m.group("incname"))), lineOffset=line["line"], forcedLink=_file)
-                    res.append(Include(_file, line["line"], line["line"] - lineOffset, line["raw"], m.group("incname")))
+                    tmp = stash.AddFile(os.path.abspath(os.path.join(os.path.dirname(
+                        _file), m.group("incname"))), lineOffset=line["line"], forcedLink=_file)
+                    res.append(Include(
+                        _file, line["line"], line["line"] - lineOffset, line["raw"], m.group("incname")))
                     if any(tmp):
                         lineOffset += max([x.InFileLine for x in tmp])
                 good = True
             if good:
                 break
         if not good:
-            res.append(Item(_file, line["line"], line["line"] - lineOffset, line["raw"]))
+            res.append(
+                Item(_file, line["line"], line["line"] - lineOffset, line["raw"]))
     return res

--- a/oelint_adv/rule_comment_notraling.py
+++ b/oelint_adv/rule_comment_notraling.py
@@ -1,8 +1,9 @@
 from oelint_adv.cls_rule import Rule
 
+
 class NoCommentsTrailing(Rule):
     def __init__(self):
-        super().__init__(id = "oelint.comments.notrailing", 
+        super().__init__(id="oelint.comments.notrailing",
                          severity="error",
                          message="Comments shall be put on seperate lines")
 

--- a/oelint_adv/rule_file_patch_signedoff.py
+++ b/oelint_adv/rule_file_patch_signedoff.py
@@ -4,23 +4,28 @@ from oelint_adv.helper_files import get_files
 from urllib.parse import urlparse
 import os
 
+
 class FilePatchIsSignedOff(Rule):
     def __init__(self):
-        super().__init__(id = "oelint.file.patchsignedoff", 
+        super().__init__(id="oelint.file.patchsignedoff",
                          severity="warning",
                          message="Patch '{FILE}' should should contain a Signed-Off entry")
 
     def check(self, _file, stash):
         res = []
         items = get_files(stash, _file, "*.patch")
-        _items = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER, attribute=Variable.ATTR_VAR, attributeValue="SRC_URI")
+        _items = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
+                                   attribute=Variable.ATTR_VAR, attributeValue="SRC_URI")
         for i in items:
             with open(i) as _input:
                 content = _input.readline()
                 if not any([x for x in content if x.startswith("Signed-off-by: ")]):
-                    ## Find matching SRC_URI assignment
-                    _assign = [x for x in _items if x.VarValue.find(os.path.basename(i)) != -1]
+                    # Find matching SRC_URI assignment
+                    _assign = [x for x in _items if x.VarValue.find(
+                        os.path.basename(i)) != -1]
                     if any(_assign):
-                        self.OverrideMsg(self.Msg.replace("{FILE}", os.path.basename(i)))
-                        res += self.finding(_assign[0].Origin, _assign[0].InFileLine)
+                        self.OverrideMsg(self.Msg.replace(
+                            "{FILE}", os.path.basename(i)))
+                        res += self.finding(_assign[0].Origin,
+                                            _assign[0].InFileLine)
         return res

--- a/oelint_adv/rule_file_patch_upstreamstatus.py
+++ b/oelint_adv/rule_file_patch_upstreamstatus.py
@@ -4,23 +4,28 @@ from oelint_adv.helper_files import get_files
 from urllib.parse import urlparse
 import os
 
+
 class FilePatchIsUpstreamStatus(Rule):
     def __init__(self):
-        super().__init__(id = "oelint.file.upstreamstatus", 
+        super().__init__(id="oelint.file.upstreamstatus",
                          severity="info",
                          message="Patch '{FILE}' should should contain a Upstream-Status entry")
 
     def check(self, _file, stash):
         res = []
         items = get_files(stash, _file, "*.patch")
-        _items = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER, attribute=Variable.ATTR_VAR, attributeValue="SRC_URI")
+        _items = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
+                                   attribute=Variable.ATTR_VAR, attributeValue="SRC_URI")
         for i in items:
             with open(i) as _input:
                 content = _input.readline()
                 if not any([x for x in content if x.startswith("Upstream-Status: ")]):
-                    ## Find matching SRC_URI assignment
-                    _assign = [x for x in _items if x.VarValue.find(os.path.basename(i)) != -1]
+                    # Find matching SRC_URI assignment
+                    _assign = [x for x in _items if x.VarValue.find(
+                        os.path.basename(i)) != -1]
                     if any(_assign):
-                        self.OverrideMsg(self.Msg.replace("{FILE}", os.path.basename(i)))
-                        res += self.finding(_assign[0].Origin, _assign[0].InFileLine)
+                        self.OverrideMsg(self.Msg.replace(
+                            "{FILE}", os.path.basename(i)))
+                        res += self.finding(_assign[0].Origin,
+                                            _assign[0].InFileLine)
         return res

--- a/oelint_adv/rule_nospace_line_begin.py
+++ b/oelint_adv/rule_nospace_line_begin.py
@@ -1,8 +1,9 @@
 from oelint_adv.cls_rule import Rule
 
+
 class NoSpaceBeginningRule(Rule):
     def __init__(self):
-        super().__init__(id = "oelint.spaces.linebeginning", 
+        super().__init__(id="oelint.spaces.linebeginning",
                          severity="warning",
                          message="Line shall not begin with a space")
 

--- a/oelint_adv/rule_nospace_line_cont.py
+++ b/oelint_adv/rule_nospace_line_cont.py
@@ -1,8 +1,9 @@
 from oelint_adv.cls_rule import Rule
 
+
 class NoSpaceRuleCont(Rule):
     def __init__(self):
-        super().__init__(id = "oelint.spaces.linecont", 
+        super().__init__(id="oelint.spaces.linecont",
                          severity="error",
                          message="No spaces after line continuation")
 

--- a/oelint_adv/rule_nospace_line_empty.py
+++ b/oelint_adv/rule_nospace_line_empty.py
@@ -1,8 +1,9 @@
 from oelint_adv.cls_rule import Rule
 
+
 class NoSpaceEmptyLineRule(Rule):
     def __init__(self):
-        super().__init__(id = "oelint.spaces.emptyline", 
+        super().__init__(id="oelint.spaces.emptyline",
                          severity="warning",
                          message="Empty lines shall not contain spaces")
 

--- a/oelint_adv/rule_nospace_line_end.py
+++ b/oelint_adv/rule_nospace_line_end.py
@@ -1,8 +1,9 @@
 from oelint_adv.cls_rule import Rule
 
+
 class NoSpaceTrailingRule(Rule):
     def __init__(self):
-        super().__init__(id = "oelint.spaces.lineend", 
+        super().__init__(id="oelint.spaces.lineend",
                          severity="warning",
                          message="Line shall not end with a space")
 

--- a/oelint_adv/rule_notabs.py
+++ b/oelint_adv/rule_notabs.py
@@ -1,8 +1,9 @@
 from oelint_adv.cls_rule import Rule
 
+
 class NoTabs(Rule):
     def __init__(self):
-        super().__init__(id = "oelint.tabs.notabs", 
+        super().__init__(id="oelint.tabs.notabs",
                          severity="warning",
                          message="Don't use tabs use spaces")
 

--- a/oelint_adv/rule_tasks_addnotaskbody.py
+++ b/oelint_adv/rule_tasks_addnotaskbody.py
@@ -3,9 +3,10 @@ from oelint_adv.cls_item import *
 from oelint_adv.const_func import FUNC_ORDER
 import os
 
+
 class TaskAddNoTaskBody(Rule):
     def __init__(self):
-        super().__init__(id = "oelint.task.addnotaskbody", 
+        super().__init__(id="oelint.task.addnotaskbody",
                          severity="warning",
                          message="The added task is not existing or has no body")
 
@@ -13,9 +14,10 @@ class TaskAddNoTaskBody(Rule):
         res = []
         for item in stash.GetItemsFor(filename=_file, classifier=TaskAdd.CLASSIFIER):
             if item.FuncName in FUNC_ORDER:
-                ## not for builtin types
+                # not for builtin types
                 continue
-            _ta = stash.GetItemsFor(filename=_file, classifier=Function.CLASSIFIER, attribute="FuncName", attributeValue=item.FuncName)
+            _ta = stash.GetItemsFor(filename=_file, classifier=Function.CLASSIFIER,
+                                    attribute="FuncName", attributeValue=item.FuncName)
             if not any(_ta):
                 res += self.finding(item.Origin, item.InFileLine)
         return res

--- a/oelint_adv/rule_tasks_customorder.py
+++ b/oelint_adv/rule_tasks_customorder.py
@@ -3,15 +3,17 @@ from oelint_adv.cls_item import *
 from oelint_adv.const_func import FUNC_ORDER
 import os
 
+
 class TaskCustomOrder(Rule):
     def __init__(self):
-        super().__init__(id = "oelint.task.customorder", 
+        super().__init__(id="oelint.task.customorder",
                          severity="error",
                          message="<FOO>")
 
     def check(self, _file, stash):
         res = []
-        items = stash.GetItemsFor(filename=_file, classifier=TaskAdd.CLASSIFIER)
+        items = stash.GetItemsFor(
+            filename=_file, classifier=TaskAdd.CLASSIFIER)
         for item in items:
             _before = item.Before
             _after = item.After
@@ -24,6 +26,7 @@ class TaskCustomOrder(Rule):
                         continue
                     _bi = FUNC_ORDER.index(_b)
                     if _ai > _bi:
-                        self.OverrideMsg("after '{}' and before '{}' breaks ordering cylce".format(_a, _b))
+                        self.OverrideMsg(
+                            "after '{}' and before '{}' breaks ordering cylce".format(_a, _b))
                         res += self.finding(item.Origin, item.InFileLine)
         return res

--- a/oelint_adv/rule_tasks_doc_strings.py
+++ b/oelint_adv/rule_tasks_doc_strings.py
@@ -3,9 +3,10 @@ from oelint_adv.cls_item import *
 from oelint_adv.const_func import FUNC_ORDER
 import os
 
+
 class TaskDocStrings(Rule):
     def __init__(self):
-        super().__init__(id = "oelint.task.docstrings", 
+        super().__init__(id="oelint.task.docstrings",
                          severity="info",
                          message="Every custom task should have a doc string set by task[doc] = \"\"")
 
@@ -13,9 +14,10 @@ class TaskDocStrings(Rule):
         res = []
         for item in stash.GetItemsFor(filename=_file, classifier=Function.CLASSIFIER):
             if item.FuncName in FUNC_ORDER:
-                ## Skip for buildin tasks
+                # Skip for buildin tasks
                 continue
-            _ta = stash.GetItemsFor(filename=_file, classifier=TaskAssignment.CLASSIFIER, attribute="FuncName", attributeValue=item.FuncName)
+            _ta = stash.GetItemsFor(filename=_file, classifier=TaskAssignment.CLASSIFIER,
+                                    attribute="FuncName", attributeValue=item.FuncName)
             if not any(_ta):
                 res += self.finding(item.Origin, item.InFileLine)
         return res

--- a/oelint_adv/rule_tasks_multiappends.py
+++ b/oelint_adv/rule_tasks_multiappends.py
@@ -2,15 +2,17 @@ from oelint_adv.cls_rule import Rule
 from oelint_adv.cls_item import *
 import os
 
+
 class TaskMultiAppends(Rule):
     def __init__(self):
-        super().__init__(id = "oelint.task.multiappends", 
+        super().__init__(id="oelint.task.multiappends",
                          severity="error",
                          message="Multiple appends to the same function in the same file won't work in bitbake")
 
     def check(self, _file, stash):
         res = []
-        _stash = stash.GetItemsFor(filename=_file, classifier=Function.CLASSIFIER)
+        _stash = stash.GetItemsFor(
+            filename=_file, classifier=Function.CLASSIFIER)
         for item in _stash:
             if not item.SubItem:
                 continue

--- a/oelint_adv/rule_tasks_no_cp.py
+++ b/oelint_adv/rule_tasks_no_cp.py
@@ -2,9 +2,10 @@ from oelint_adv.cls_rule import Rule
 from oelint_adv.cls_item import *
 import os
 
+
 class TaskInstallNoCp(Rule):
     def __init__(self):
-        super().__init__(id = "oelint.task.nocopy", 
+        super().__init__(id="oelint.task.nocopy",
                          severity="error",
                          message="'cp' shall not be used in do_install. Use 'install'")
 

--- a/oelint_adv/rule_tasks_no_mkdir.py
+++ b/oelint_adv/rule_tasks_no_mkdir.py
@@ -2,9 +2,10 @@ from oelint_adv.cls_rule import Rule
 from oelint_adv.cls_item import *
 import os
 
+
 class TaskInstallNoMkdir(Rule):
     def __init__(self):
-        super().__init__(id = "oelint.task.nomkdir", 
+        super().__init__(id="oelint.task.nomkdir",
                          severity="error",
                          message="'mkdir' shall not be used in do_install. Use 'install'")
 

--- a/oelint_adv/rule_tasks_order.py
+++ b/oelint_adv/rule_tasks_order.py
@@ -3,22 +3,26 @@ from oelint_adv.cls_item import *
 from oelint_adv.const_func import FUNC_ORDER
 import os
 
+
 class TaskOrder(Rule):
     def __init__(self):
-        super().__init__(id = "oelint.task.order", 
+        super().__init__(id="oelint.task.order",
                          severity="warning",
                          message="<FOO>")
 
     def check(self, _file, stash):
         res = []
-        items = stash.GetItemsFor(filename=_file, classifier=Function.CLASSIFIER)
+        items = stash.GetItemsFor(
+            filename=_file, classifier=Function.CLASSIFIER)
         for item in items:
-            _func_before = sorted([x for x in items if x.Line < item.Line and x.FuncName in FUNC_ORDER], key=lambda x: x.Line, reverse=True)
+            _func_before = sorted(
+                [x for x in items if x.Line < item.Line and x.FuncName in FUNC_ORDER], key=lambda x: x.Line, reverse=True)
             if any(_func_before):
                 _func_before = _func_before[0]
                 if not item.FuncName in FUNC_ORDER:
                     continue
                 if FUNC_ORDER.index(item.FuncName) < FUNC_ORDER.index(_func_before.FuncName):
-                    self.OverrideMsg("'{}' should be placed before '{}'".format(item.FuncName, _func_before.FuncName))
+                    self.OverrideMsg("'{}' should be placed before '{}'".format(
+                        item.FuncName, _func_before.FuncName))
                     res += self.finding(item.Origin, item.InFileLine)
         return res

--- a/oelint_adv/rule_var_bugtracker_url.py
+++ b/oelint_adv/rule_var_bugtracker_url.py
@@ -2,15 +2,17 @@ from oelint_adv.cls_rule import Rule
 from oelint_adv.cls_item import *
 from urllib.parse import urlparse
 
+
 class VarBugtrackerIsUrl(Rule):
     def __init__(self):
-        super().__init__(id = "oelint.vars.bugtrackerisurl", 
+        super().__init__(id="oelint.vars.bugtrackerisurl",
                          severity="warning",
                          message="'BUGTRACKER' should be an URL")
 
     def check(self, _file, stash):
         res = []
-        items = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER, attribute=Variable.ATTR_VAR, attributeValue="BUGTRACKER")
+        items = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
+                                  attribute=Variable.ATTR_VAR, attributeValue="BUGTRACKER")
         for i in items:
             val = i.VarValue.replace("\"", "").strip()
             try:

--- a/oelint_adv/rule_var_depends_append.py
+++ b/oelint_adv/rule_var_depends_append.py
@@ -1,15 +1,17 @@
 from oelint_adv.cls_rule import Rule
 from oelint_adv.cls_item import *
 
+
 class VarHomepagePrefix(Rule):
     def __init__(self):
-        super().__init__(id = "oelint.vars.dependsappend", 
+        super().__init__(id="oelint.vars.dependsappend",
                          severity="error",
                          message="DEPENDS should only be appended, not overwritten")
 
     def check(self, _file, stash):
         res = []
-        items = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER, attribute=Variable.ATTR_VAR, attributeValue="DEPENDS")
+        items = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
+                                  attribute=Variable.ATTR_VAR, attributeValue="DEPENDS")
         for i in items:
             if not i.IsAppend():
                 res += self.finding(i.Origin, i.InFileLine)

--- a/oelint_adv/rule_var_homepage.py
+++ b/oelint_adv/rule_var_homepage.py
@@ -1,15 +1,17 @@
 from oelint_adv.cls_rule import Rule
 from oelint_adv.cls_item import *
 
+
 class VarHomepagePrefix(Rule):
     def __init__(self):
-        super().__init__(id = "oelint.vars.homepageprefix", 
+        super().__init__(id="oelint.vars.homepageprefix",
                          severity="warning",
                          message="'HOMEPAGE' should start with 'http://' or 'https://'")
 
     def check(self, _file, stash):
         res = []
-        items = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER, attribute=Variable.ATTR_VAR, attributeValue="HOMEPAGE")
+        items = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
+                                  attribute=Variable.ATTR_VAR, attributeValue="HOMEPAGE")
         for i in items:
             tmp = i.VarValue.strip('"').strip()
             if not any([x for x in ["https://", "http://"] if tmp.startswith(x)]):

--- a/oelint_adv/rule_var_license_remote.py
+++ b/oelint_adv/rule_var_license_remote.py
@@ -4,15 +4,17 @@ from oelint_adv.helper_files import get_scr_components
 from urllib.parse import urlparse
 import os
 
+
 class VarLicenseRemoteFile(Rule):
     def __init__(self):
-        super().__init__(id = "oelint.var.licenseremotefile", 
+        super().__init__(id="oelint.var.licenseremotefile",
                          severity="warning",
                          message="License-File should be a remote file")
 
     def check(self, _file, stash):
         res = []
-        _items = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER, attribute=Variable.ATTR_VAR, attributeValue="LIC_FILES_CHKSUM")
+        _items = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
+                                   attribute=Variable.ATTR_VAR, attributeValue="LIC_FILES_CHKSUM")
         for i in _items:
             components = get_scr_components(i.VarValue)
             if any(components) and components["proto"] == "file":

--- a/oelint_adv/rule_var_multilineindent.py
+++ b/oelint_adv/rule_var_multilineindent.py
@@ -1,15 +1,17 @@
 from oelint_adv.cls_rule import Rule
 from oelint_adv.cls_item import *
 
+
 class VarMultiLineIndent(Rule):
     def __init__(self):
-        super().__init__(id = "oelint.vars.multilineident", 
+        super().__init__(id="oelint.vars.multilineident",
                          severity="info",
                          message="On a multiline assignment, line indent is desirable. Current {}/{}")
 
     def check(self, _file, stash):
         res = []
-        items = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER)
+        items = stash.GetItemsFor(
+            filename=_file, classifier=Variable.CLASSIFIER)
         for i in items:
             if not i.IsMultiLine():
                 continue
@@ -24,5 +26,6 @@ class VarMultiLineIndent(Rule):
                 for _line in _lines[1:]:
                     _thisline = (len(_line) - len(_line.lstrip(" "))) - 1
                     if _thisline < _calcoffset:
-                        res += self.finding(i.Origin, i.InFileLine + _lines.index(_line), self.FormatMsg(_thisline, _calcoffset))               
+                        res += self.finding(i.Origin, i.InFileLine + _lines.index(
+                            _line), self.FormatMsg(_thisline, _calcoffset))
         return res

--- a/oelint_adv/rule_var_quoted.py
+++ b/oelint_adv/rule_var_quoted.py
@@ -1,15 +1,17 @@
 from oelint_adv.cls_rule import Rule
 from oelint_adv.cls_item import *
 
+
 class VarQuoted(Rule):
     def __init__(self):
-        super().__init__(id = "oelint.vars.valuequoted", 
+        super().__init__(id="oelint.vars.valuequoted",
                          severity="error",
                          message="Variable value should be quoted")
 
     def check(self, _file, stash):
         res = []
-        items = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER)
+        items = stash.GetItemsFor(
+            filename=_file, classifier=Variable.CLASSIFIER)
         for i in items:
             if i.VarName == "inherit":
                 continue

--- a/oelint_adv/rule_var_section_lowercase.py
+++ b/oelint_adv/rule_var_section_lowercase.py
@@ -1,15 +1,17 @@
 from oelint_adv.cls_rule import Rule
 from oelint_adv.cls_item import *
 
+
 class VarSectionLowercase(Rule):
     def __init__(self):
-        super().__init__(id = "oelint.vars.sectionlowercase", 
+        super().__init__(id="oelint.vars.sectionlowercase",
                          severity="warning",
                          message="'SECTION' should only lowercase characters")
 
     def check(self, _file, stash):
         res = []
-        items = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER, attribute=Variable.ATTR_VAR, attributeValue="SECTION")
+        items = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
+                                  attribute=Variable.ATTR_VAR, attributeValue="SECTION")
         for i in items:
             if not i.VarValue.islower():
                 res += self.finding(i.Origin, i.InFileLine)

--- a/oelint_adv/rule_var_spaces_assignment.py
+++ b/oelint_adv/rule_var_spaces_assignment.py
@@ -1,15 +1,17 @@
 from oelint_adv.cls_rule import Rule
 from oelint_adv.cls_item import *
 
+
 class VarSpacesOnAssignment(Rule):
     def __init__(self):
-        super().__init__(id = "oelint.vars.spacesassignment", 
+        super().__init__(id="oelint.vars.spacesassignment",
                          severity="warning",
                          message="Suggest spaces around variable assignment. E.g. 'FOO = \"BAR\"'")
 
     def check(self, _file, stash):
         res = []
-        items = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER)
+        items = stash.GetItemsFor(
+            filename=_file, classifier=Variable.CLASSIFIER)
         for i in items:
             if i.VarName == "inherit":
                 continue

--- a/oelint_adv/rule_var_src_uri_wildcard.py
+++ b/oelint_adv/rule_var_src_uri_wildcard.py
@@ -4,15 +4,17 @@ from oelint_adv.helper_files import get_scr_components
 from urllib.parse import urlparse
 import os
 
+
 class VarSRCURIWildcard(Rule):
     def __init__(self):
-        super().__init__(id = "oelint.var.srcuriwildcard", 
+        super().__init__(id="oelint.var.srcuriwildcard",
                          severity="error",
                          message="'SRC_URI' should not contain any wildcards")
 
     def check(self, _file, stash):
         res = []
-        _items = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER, attribute=Variable.ATTR_VAR, attributeValue="SRC_URI")
+        _items = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
+                                   attribute=Variable.ATTR_VAR, attributeValue="SRC_URI")
         for i in _items:
             for f in [x for x in i.VarValue.split(" ") if x]:
                 components = get_scr_components(f)

--- a/oelint_adv/rule_var_summary_80chars.py
+++ b/oelint_adv/rule_var_summary_80chars.py
@@ -1,15 +1,17 @@
 from oelint_adv.cls_rule import Rule
 from oelint_adv.cls_item import *
 
+
 class VarSummary80Chars(Rule):
     def __init__(self):
-        super().__init__(id = "oelint.vars.summary80chars", 
+        super().__init__(id="oelint.vars.summary80chars",
                          severity="warning",
                          message="'SUMMARY' should not be longer than 80 characters")
 
     def check(self, _file, stash):
         res = []
-        items = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER, attribute=Variable.ATTR_VAR, attributeValue="SUMMARY")
+        items = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
+                                  attribute=Variable.ATTR_VAR, attributeValue="SUMMARY")
         for i in items:
             val = i.VarValue.strip()
             if len(val) > 80:

--- a/oelint_adv/rule_var_summary_linebreaks.py
+++ b/oelint_adv/rule_var_summary_linebreaks.py
@@ -1,15 +1,17 @@
 from oelint_adv.cls_rule import Rule
 from oelint_adv.cls_item import *
 
+
 class VarSummaryLinebreaks(Rule):
     def __init__(self):
-        super().__init__(id = "oelint.vars.summarylinebreaks", 
+        super().__init__(id="oelint.vars.summarylinebreaks",
                          severity="warning",
                          message="'SUMMARY' should not contain line breaks")
 
     def check(self, _file, stash):
         res = []
-        items = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER, attribute=Variable.ATTR_VAR, attributeValue="SUMMARY")
+        items = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
+                                  attribute=Variable.ATTR_VAR, attributeValue="SUMMARY")
         for i in items:
             if i.Raw.strip().find("\\n") != -1:
                 res += self.finding(i.Origin, i.InFileLine)

--- a/oelint_adv/rule_vars_bbclassextends.py
+++ b/oelint_adv/rule_vars_bbclassextends.py
@@ -1,16 +1,19 @@
 from oelint_adv.cls_rule import Rule
 from oelint_adv.cls_item import *
 
+
 class VarBbclassextend(Rule):
     def __init__(self):
-        super().__init__(id = "oelint.var.bbclassextend", 
+        super().__init__(id="oelint.var.bbclassextend",
                          severity="info",
                          message="BBCLASSEXTEND should be set if possible")
 
     def check(self, _file, stash):
         res = []
-        items = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER, attribute=Variable.ATTR_VAR, attributeValue="BBCLASSEXTEND")
-        items_inherit = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER, attribute=Variable.ATTR_VAR, attributeValue="inherit")
+        items = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
+                                  attribute=Variable.ATTR_VAR, attributeValue="BBCLASSEXTEND")
+        items_inherit = stash.GetItemsFor(
+            filename=_file, classifier=Variable.CLASSIFIER, attribute=Variable.ATTR_VAR, attributeValue="inherit")
         if not any(items):
             if not any([x for x in items_inherit if x.VarValue.find("native") != -1]):
                 res += self.finding(_file, 0)

--- a/oelint_adv/rule_vars_mandatory_exists.py
+++ b/oelint_adv/rule_vars_mandatory_exists.py
@@ -2,16 +2,18 @@ from oelint_adv.cls_rule import Rule
 from oelint_adv.cls_item import *
 from oelint_adv.const_vars import MANDATORY_VARS
 
+
 class VarMandatoryExists(Rule):
     def __init__(self):
-        super().__init__(id = "oelint.var.mandatoryvar", 
+        super().__init__(id="oelint.var.mandatoryvar",
                          severity="error",
                          message="<FOO>")
 
     def check(self, _file, stash):
         res = []
         for var in MANDATORY_VARS:
-            items = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER, attribute=Variable.ATTR_VAR, attributeValue=var)
+            items = stash.GetItemsFor(
+                filename=_file, classifier=Variable.CLASSIFIER, attribute=Variable.ATTR_VAR, attributeValue=var)
             if not any(items):
                 self.OverrideMsg("Variable '{}' should be set".format(var))
                 res += self.finding(_file, 0)

--- a/oelint_adv/rule_vars_multiinclude.py
+++ b/oelint_adv/rule_vars_multiinclude.py
@@ -2,20 +2,23 @@ from oelint_adv.cls_rule import Rule
 from oelint_adv.cls_item import *
 import re
 
+
 class VarMultiInclude(Rule):
     def __init__(self):
-        super().__init__(id = "oelint.var.multiinclude", 
+        super().__init__(id="oelint.var.multiinclude",
                          severity="warning",
                          message="'{INC}' is included multiple times")
 
     def check(self, _file, stash):
         res = []
-        items = stash.GetItemsFor(filename=_file, classifier=Include.CLASSIFIER)
+        items = stash.GetItemsFor(
+            filename=_file, classifier=Include.CLASSIFIER)
         keys = []
         for i in items:
             keys += [x.strip() for x in re.split("\s|,", i.IncName) if x]
         for key in list(set(keys)):
             _i = [x for x in items if x.IncName.find(key) != -1]
             if len(_i) > 1:
-                res += self.finding(_i[-1].Origin, _i[-1].InFileLine, self.Msg.replace("{INC}", key))
+                res += self.finding(_i[-1].Origin, _i[-1].InFileLine,
+                                    self.Msg.replace("{INC}", key))
         return res

--- a/oelint_adv/rule_vars_multiinherit.py
+++ b/oelint_adv/rule_vars_multiinherit.py
@@ -2,20 +2,23 @@ from oelint_adv.cls_rule import Rule
 from oelint_adv.cls_item import *
 import re
 
+
 class VarMultiInherit(Rule):
     def __init__(self):
-        super().__init__(id = "oelint.var.multiinherit", 
+        super().__init__(id="oelint.var.multiinherit",
                          severity="warning",
                          message="'{INH}' is included multiple times")
 
     def check(self, _file, stash):
         res = []
-        items = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER, attribute=Variable.ATTR_VAR, attributeValue="inherit")
+        items = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
+                                  attribute=Variable.ATTR_VAR, attributeValue="inherit")
         keys = []
         for i in items:
             keys += [x.strip() for x in re.split("\s|,", i.VarValue) if x]
         for key in list(set(keys)):
             _i = [x for x in items if x.VarValue.find(key) != -1]
             if len(_i) > 1:
-                res += self.finding(_i[-1].Origin, _i[-1].InFileLine, self.Msg.replace("{INH}", key))
+                res += self.finding(_i[-1].Origin, _i[-1].InFileLine,
+                                    self.Msg.replace("{INH}", key))
         return res

--- a/oelint_adv/rule_vars_native_filename.py
+++ b/oelint_adv/rule_vars_native_filename.py
@@ -1,17 +1,19 @@
 from oelint_adv.cls_rule import Rule
 from oelint_adv.cls_item import *
 
+
 class VarNativeFilename(Rule):
     def __init__(self):
-        super().__init__(id = "oelint.var.nativefilename", 
+        super().__init__(id="oelint.var.nativefilename",
                          severity="warning",
                          message="native-recipe-files should include '-native' in file name")
 
     def check(self, _file, stash):
         res = []
-        items = [x for x in \
-                stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER, attribute=Variable.ATTR_VAR, attributeValue="inherit") \
-                if x.VarValue.strip() == "native"]
+        items = [x for x in
+                 stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
+                                   attribute=Variable.ATTR_VAR, attributeValue="inherit")
+                 if x.VarValue.strip() == "native"]
         if any(items):
             if _file.find("-native") == -1:
                 res += self.finding(_file, 0)

--- a/oelint_adv/rule_vars_order.py
+++ b/oelint_adv/rule_vars_order.py
@@ -3,22 +3,26 @@ from oelint_adv.cls_item import *
 from oelint_adv.const_vars import VAR_ORDER
 import os
 
+
 class VarsOrder(Rule):
     def __init__(self):
-        super().__init__(id = "oelint.var.order", 
+        super().__init__(id="oelint.var.order",
                          severity="warning",
                          message="<FOO>")
 
     def check(self, _file, stash):
         res = []
-        items = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER)
+        items = stash.GetItemsFor(
+            filename=_file, classifier=Variable.CLASSIFIER)
         for item in items:
-            _func_before = sorted([x for x in items if x.Line < item.Line and x.VarName in VAR_ORDER], key=lambda x: x.Line, reverse=True)
+            _func_before = sorted(
+                [x for x in items if x.Line < item.Line and x.VarName in VAR_ORDER], key=lambda x: x.Line, reverse=True)
             if any(_func_before):
                 _func_before = _func_before[0]
                 if not item.VarName in VAR_ORDER:
                     continue
                 if VAR_ORDER.index(item.VarName) < VAR_ORDER.index(_func_before.VarName):
-                    self.OverrideMsg("'{}' should be placed before '{}'".format(item.VarName, _func_before.VarName))
+                    self.OverrideMsg("'{}' should be placed before '{}'".format(
+                        item.VarName, _func_before.VarName))
                     res += self.finding(item.Origin, item.InFileLine)
         return res

--- a/oelint_adv/rule_vars_suggested.py
+++ b/oelint_adv/rule_vars_suggested.py
@@ -2,16 +2,18 @@ from oelint_adv.cls_rule import Rule
 from oelint_adv.cls_item import *
 from oelint_adv.const_vars import SUGGESTED_VARS
 
+
 class VarSuggestedExists(Rule):
     def __init__(self):
-        super().__init__(id = "oelint.var.suggestedvar", 
+        super().__init__(id="oelint.var.suggestedvar",
                          severity="info",
                          message="<FOO>")
 
     def check(self, _file, stash):
         res = []
         for var in SUGGESTED_VARS:
-            items = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER, attribute=Variable.ATTR_VAR, attributeValue=var)
+            items = stash.GetItemsFor(
+                filename=_file, classifier=Variable.CLASSIFIER, attribute=Variable.ATTR_VAR, attributeValue=var)
             if not any(items):
                 self.OverrideMsg("Variable '{}' should be set".format(var))
                 res += self.finding(_file, 0)

--- a/oelint_adv/rule_vars_variable_override.py
+++ b/oelint_adv/rule_vars_variable_override.py
@@ -2,23 +2,27 @@ from oelint_adv.cls_rule import Rule
 from oelint_adv.cls_item import *
 import os
 
+
 class VarOverride(Rule):
     def __init__(self):
-        super().__init__(id = "oelint.var.override", 
+        super().__init__(id="oelint.var.override",
                          severity="error",
                          message="<FOO>")
 
     def check(self, _file, stash):
         res = []
-        __varnames = [x.VarName for x in stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER)]
+        __varnames = [x.VarName for x in stash.GetItemsFor(
+            filename=_file, classifier=Variable.CLASSIFIER)]
         for v in __varnames:
             if v == "inherit":
-                ## This will be done by another rule
+                # This will be done by another rule
                 continue
-            items = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER, attribute=Variable.ATTR_VAR, attributeValue=v)
+            items = stash.GetItemsFor(
+                filename=_file, classifier=Variable.CLASSIFIER, attribute=Variable.ATTR_VAR, attributeValue=v)
             items = sorted(items, key=lambda x: x.Line, reverse=False)
             if len(items) > 1:
                 if all([not x.IsAppend() for x in items]):
-                    self.OverrideMsg("Variable '{}' is set by {}".format(v, ",".join([os.path.basename(x.Origin) for x in items])))
+                    self.OverrideMsg("Variable '{}' is set by {}".format(
+                        v, ",".join([os.path.basename(x.Origin) for x in items])))
                     res += self.finding(items[0].Origin, items[0].InFileLine)
         return res


### PR DESCRIPTION
Ignore PyCharm and VSCode files and apply PEP8 rules with autopep8 tool.