### PR TITLE
Add instruction to install oelint-adv from Arch Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,13 @@ The tool does handle includes/requires automatically so you don't have to pass t
 
 **NOTE**: .bbappend-files have to be passed via CLI - these are NOT gathered automatically
 
+## Install
+
+From Arch Linux:
+```
+yay -S oelint-adv
+```
+
 ## Usage
 
 ```shell


### PR DESCRIPTION
I made an [oelint-adv Arch Linux package](https://aur.archlinux.org/packages/oelint-adv). This is the instruction how install it from Arch Linux.