### PR TITLE
Import rules relative to base package

### DIFF
--- a/oelint_adv/cls_rule.py
+++ b/oelint_adv/cls_rule.py
@@ -40,7 +40,7 @@ def load_rules(add_rules=[]):
         _searchpath = os.path.join(os.path.dirname(os.path.abspath(__file__)), v["path"])
         packages = pkgutil.walk_packages(path=[_searchpath])
         for _, name, _ in packages:
-            name = v["path"] + "." + name
+            name = __name__.split(".")[0] + "." + v["path"] + "." + name
             mod = importlib.import_module(name)
             for m in inspect.getmembers(mod, inspect.isclass):
                 try:


### PR DESCRIPTION
Importing oelint-adv as a module results in runtime errors. This modifies
the way rules are ingested to ensure that oelint-adv can be imported as
a module and not just run with the oelint-adv binary.