### PR TITLE
Add missing '[id]' to output format documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ optional arguments:
 
 ## Output
 
-Will be [file]:[line]:[severity]:[message].
+Will be [file]:[line]:[severity]:[id]:[message].
 
 Example:
 


### PR DESCRIPTION
`id` is part of the output, but not listed in the format.