### PR TITLE
--exit-zero argument to always return 0

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,13 @@ yay -S oelint-adv
 
 ```shell
 oelint-adv
-usage: oelint-adv [-h] [--suppress SUPPRESS] [--output OUTPUT] [--fix] [--nobackup] [--addrules ADDRULES [ADDRULES ...]]
-                  [--customrules CUSTOMRULES [CUSTOMRULES ...]] [--rulefile RULEFILE] [--constantfile CONSTANTFILE] [--color] [--quiet] [--noinfo] [--nowarn]
+usage: oelint-adv [-h] [--suppress SUPPRESS] [--output OUTPUT] [--fix]
+                  [--nobackup] [--addrules ADDRULES [ADDRULES ...]]
+                  [--customrules CUSTOMRULES [CUSTOMRULES ...]]
+                  [--rulefile RULEFILE] [--constantfile CONSTANTFILE]
+                  [--color] [--quiet] [--noinfo] [--nowarn]
                   [--constantmods CONSTANTMODS [CONSTANTMODS ...]]
+                  [--exit-zero]
                   files [files ...]
 
 Advanced OELint - Check bitbake recipes against OECore styleguide
@@ -69,7 +73,12 @@ optional arguments:
   --noinfo              Don't print information level findings
   --nowarn              Don't print warning level findings
   --constantmods CONSTANTMODS [CONSTANTMODS ...]
-                        Modifications to the constant db. prefix with: + - to add to DB, - - to remove from DB, None - to override DB
+                        Modifications to the constant db. prefix with: + - to
+                        add to DB, - - to remove from DB, None - to override
+                        DB
+  --exit-zero           Always return a 0 (non-error) status code, even if
+                        lint errors are found
+
 ```
 
 ## Output

--- a/oelint_adv/__main__.py
+++ b/oelint_adv/__main__.py
@@ -51,6 +51,8 @@ def create_argparser():
                              - - to remove from DB,
                              None - to override DB
                             """)
+    parser.add_argument("--exit-zero", action="store_true", default=False,
+        help="Always return a 0 (non-error) status code, even if lint errors are found")
     parser.add_argument("files", nargs='+', help="File to parse")
 
     return parser
@@ -74,7 +76,7 @@ def arguments_post(args):
         except (FileNotFoundError, json.JSONDecodeError):
             raise argparse.ArgumentTypeError(
                 "'constantfile' is not a valid file")
- 
+
     for mod in args.constantmods:
         try:
             with open(mod.lstrip('+-')) as _in:
@@ -130,7 +132,7 @@ def group_files(files):
             if not _filename_key in res: # pragma: no cover
                 res[_filename_key] = set()
             res[_filename_key].add(f)
-    
+
     # as sets are unordered, we convert them to sorted lists at this point
     # order is like the files have been passed via CLI
     for k, v in res.items():
@@ -201,7 +203,9 @@ def main():  # pragma: no cover
     args.output.write("\n".join([x[1] for x in issues]) + "\n")
     if args.output != sys.stderr:
         args.output.close()
-    sys.exit(len(issues))
+
+    exit_code = len(issues) if not args.exit_zero else 0
+    sys.exit(exit_code)
 
 if __name__ == '__main__':
     main()  # pragma: no cover

--- a/tests/test_class_integration.py
+++ b/tests/test_class_integration.py
@@ -581,3 +581,18 @@ class TestClassIntegration(TestBaseClass):
         ))
         issues = [x[1] for x in run(_args)]
         assert(not any(issues))
+
+    @pytest.mark.parametrize('input',
+        [
+            {
+            'oelint adv-test.bb':
+            '''
+            VAR = "1"
+            INSANE_SKIP_${PN} = "foo"
+            '''
+            }
+        ],
+    )
+    def test_exit_zero(self, input):
+        _args = self._create_args(input, extraopts=["--exit-zero"])
+        assert(_args.exit_zero)


### PR DESCRIPTION
Adds the `--exit-zero` argument which sets the exit code to ´0` (successful) even on found issues. Scenarios to do this are eg. CI builds where the results are evaluated in later stages.