### PR TITLE
Add --print-ruleset option

### DIFF
--- a/oelint_adv/cls_rule.py
+++ b/oelint_adv/cls_rule.py
@@ -133,6 +133,18 @@ class Rule():
         """
         return [self.ID] + ["{}.{}".format(self.ID, x) for x in self.Appendix]
 
+    def GetRulefileEntries(self):
+        """Returns a dictionary of entries which would represent the currently
+        enabled ruleset (for this rule) in a rulefile.
+
+        Returns:
+            dict -- list of rulefile entries
+        """
+        return {
+            **({} if self.GetSeverity() is None else {self.ID: self.GetSeverity()}),
+            **{f"{self.ID}.{x}": self.GetSeverity(x) for x in self.Appendix if self.GetSeverity(x) is not None},
+        }
+
     def FormatMsg(self, *args):
         """Format message
 


### PR DESCRIPTION
Hi,

I was trying to build my own ruleset and didn't find any way to query the defaults.  So I thought it might make sense to add an option which prints the currently loaded ruleset.  This can then be used as a baseline to start customizing it...

What do you think?