### PR TITLE
Fix appendix from rule files handling

### DIFF
--- a/tests/test_class_integration.py
+++ b/tests/test_class_integration.py
@@ -547,6 +547,25 @@ class TestClassIntegration(TestBaseClass):
             {
             'oelint adv-test.bb':
             '''
+            DESCRIPTION = "foo"
+            '''
+            }
+        ],
+    )
+    def test_rulefile_filtering2(self, input):
+        from oelint_adv.__main__ import run
+
+        _cstfile = self._create_tempfile('constants.json', '{"oelint.var.mandatoryvar.DESCRIPTION": "warning"}')
+
+        _args = self._create_args(input, extraopts=["--rulefile={}".format(_cstfile)])
+        issues = [x[1] for x in run(_args)]
+        assert(not any(issues))
+
+    @pytest.mark.parametrize('input',
+        [
+            {
+            'oelint adv-test.bb':
+            '''
             HOMEPAGE = "foo"
             '''
             }


### PR DESCRIPTION
Noticed this while working on #235...  This is a followup for commit 41ca6cb54286 ("cls_rule: mind appendix from rule files").

A rulefile containing just an appendix rule, for example:

    {
        "oelint.var.mandatoryvar.DESCRIPTION": "warning"
    }

would erroneously also enable all other `oelint.var.mandatoryvar` rules at their default severity.

Ref: #236