### PR TITLE
listappend: Actually fix the mixup in the lint message

### DIFF
--- a/oelint_adv/rule_base/rule_vars_listappend.py
+++ b/oelint_adv/rule_base/rule_vars_listappend.py
@@ -19,7 +19,7 @@ class VarListAppend(Rule):
                 continue
             ops = i.AppendOperation()
             if not i.VarValue.startswith("\" ") and any(x in ops for x in ["append", " .= "]):
-                res += self.finding(i.Origin, i.InFileLine, override_msg="Append to list should end with a blank")
+                res += self.finding(i.Origin, i.InFileLine, override_msg="Append to list should start with a blank")
             if not i.VarValue.endswith(" \"") and any(x in ops for x in ["prepend", " =. "]):
-                res += self.finding(i.Origin, i.InFileLine, override_msg="Prepend to list should start with a blank")
+                res += self.finding(i.Origin, i.InFileLine, override_msg="Prepend to list should end with a blank")
         return res

--- a/oelint_adv/rule_base/rule_vars_listappend.py
+++ b/oelint_adv/rule_base/rule_vars_listappend.py
@@ -17,6 +17,9 @@ class VarListAppend(Rule):
         for i in items:
             if not any(i.VarName.startswith(x) for x in needles):
                 continue
+            if i.VarName.startswith("FILESEXTRAPATHS"):
+                # Catched by the `FILES` above but this list is colon separated.
+                continue
             ops = i.AppendOperation()
             if not i.VarValue.startswith("\" ") and any(x in ops for x in ["append", " .= "]):
                 res += self.finding(i.Origin, i.InFileLine, override_msg="Append to list should start with a blank")


### PR DESCRIPTION
For appending, you need to start with a blank, for prepending you need to end with a blank.

Followup fix for 52e7ddbc9737 ("Fix mixup in error message").

Additionally, fix this lint triggering false-positive for `FILESEXTRAPATHS`.

Fixes #238.