### PR TITLE
Fix default severity from rulefile

### DIFF
--- a/oelint_adv/cls_rule.py
+++ b/oelint_adv/cls_rule.py
@@ -118,12 +118,13 @@ class Rule():
             return self.Severity
         _subid = None if appendix is None else f"{self.ID}.{appendix}"
         if _subid and _subid in _rule_file:
-            return _rule_file[_subid]
+            _severity = _rule_file[_subid]
         elif self.ID in _rule_file:
-            return _rule_file[self.ID]
+            _severity = _rule_file[self.ID]
         else:
             # rule not in rulefile
             return None
+        return _severity if _severity != "" else self.Severity
 
     def GetIDs(self):
         """Returns all possible IDs of the rule

--- a/tests/test_class_integration.py
+++ b/tests/test_class_integration.py
@@ -170,6 +170,22 @@ class TestClassIntegration(TestBaseClass):
         self.check_for_id(self._create_args(input, _extra_opts), 'oelint.var.suggestedvar.CVE_PRODUCT', 0)
         self.check_for_id(self._create_args(input, _extra_opts), 'oelint.var.suggestedvar.BBCLASSEXTEND', 1)
 
+    @pytest.mark.parametrize('input',
+        [
+            {
+            'oelint adv-test.bb':
+            '''
+            VAR = "1"
+            '''
+            }
+        ],
+    )
+    def test_rulefile_default_severity(self, input):
+        from oelint_adv.__main__ import run
+        _rule_file = self._create_tempfile('rulefile', '{"oelint.var.mandatoryvar": ""}')
+        _args = self._create_args(input, extraopts=[f"--rulefile={_rule_file}"])
+        for issue in [x[1] for x in run(_args)]:
+            assert ":error:" in issue
 
     @pytest.mark.parametrize('id', ['oelint.var.override'])
     @pytest.mark.parametrize('occurance', [0])


### PR DESCRIPTION
When a rule's value in the rulefile is set to `""`, then the rule should use its default severity.  This behavior regressed in the last release.

Properly fall back to the default severity when `""` is found in the rulefile and add a testcase to prevent this from happening again in the future.

Fixes #241.