### PR TITLE
srcurioptions: Allow type=kmeta option

### DIFF
--- a/oelint_adv/rule_base/rule_var_src_uri.py
+++ b/oelint_adv/rule_base/rule_var_src_uri.py
@@ -137,9 +137,11 @@ class VarSRCUriOptions(Rule):
             res += self.finding(i.Origin, i.InFileLine + _index,
                                 "Fetcher '{}' is not known".format(_url["scheme"]))
         else:
-            for k, _ in _url["options"].items():
+            for k, v in _url["options"].items():
                 if _url["scheme"] not in self._valid_options:
                     continue # pragma: no cover
+                if k == "type" and v == "kmeta":
+                    continue # linux-yocto uses this option to indicate kernel metadata sources
                 if k not in self._valid_options[_url["scheme"]] + self._general_options:
                     res += self.finding(i.Origin, i.InFileLine + _index,
                                         "Option '{}' is not known with this fetcher type".format(k))

--- a/tests/test_class_oelint_vars_srcurioptions.py
+++ b/tests/test_class_oelint_vars_srcurioptions.py
@@ -787,3 +787,24 @@ class TestClassOelintVarsSRCURIOptions(TestBaseClass):
     )
     def test_good_edgecases_bad(self, input, id, occurance):
         self.check_for_id(self._create_args(input), id, occurance)
+
+    @pytest.mark.parametrize('id', ['oelint.vars.srcurioptions'])
+    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('input',
+        [
+            {
+            'oelint_adv_test.bb':
+            '''
+            SRC_URI += "file://kmeta/common;type=kmeta"
+            '''
+            },
+            {
+            'oelint_adv_test.bb':
+            '''
+            SRC_URI += "git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=yocto-5.10;destsuffix=${KMETA}"
+            '''
+            },
+        ],
+    )
+    def test_type_kmeta_allowed(self, input, id, occurance):
+        self.check_for_id(self._create_args(input), id, occurance)


### PR DESCRIPTION
The `linux-yocto` class uses the `type=kmeta` SRC_URI option to designate kernel metadata sources.  Thus, oelint-adv should not trigger a lint about it being unknown.

As there is no good way to check for linux-yocto inheritance when bbappends across layers are involved, the chosen solution is to always allow this option.  The chance for a false negative should be quite low...

Fixes: #245

# Pull request checklist
## Bugfix
- [x] A testcase was added to test the behavior