### PR TITLE
replace occurance(s)->occurrence(s)

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -59,9 +59,9 @@ class TestBaseClass():
         from oelint_adv.__main__ import create_argparser
         return create_argparser()
 
-    def check_for_id(self, args, id, occurences):
+    def check_for_id(self, args, id, occurrences):
         from oelint_adv.__main__ import run
         issues = [x[1] for x in run(args)]
         _files = '\n---\n'.join(['{}:\n{}'.format(k,v) for k,v in self.__created_files.items()])
         assert(len([x for x in issues if ':{}:'.format(id) in x]) ==
-               occurences), '{} expected {} time(s) in:\n{}\n\n---\n{}'.format(id, occurences, '\n'.join(issues), _files)
+               occurrences), '{} expected {} time(s) in:\n{}\n\n---\n{}'.format(id, occurrences, '\n'.join(issues), _files)

--- a/tests/test_class_integration.py
+++ b/tests/test_class_integration.py
@@ -188,7 +188,7 @@ class TestClassIntegration(TestBaseClass):
             assert ":error:" in issue
 
     @pytest.mark.parametrize('id', ['oelint.var.override'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -325,11 +325,11 @@ class TestClassIntegration(TestBaseClass):
             }
         ],
     )
-    def test_grouping(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_grouping(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.var.override'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -466,8 +466,8 @@ class TestClassIntegration(TestBaseClass):
             }
         ],
     )
-    def test_grouping_with_missing_files(self, input, id, occurance):
-        self.check_for_id(self._create_args(input, extraopts=["/does/not/exist"]), id, occurance)
+    def test_grouping_with_missing_files(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input, extraopts=["/does/not/exist"]), id, occurrence)
 
     @pytest.mark.parametrize('input', 
         [

--- a/tests/test_class_oelint_append_protvars.py
+++ b/tests/test_class_oelint_append_protvars.py
@@ -15,7 +15,7 @@ class TestClassOelintAppendProtVars(TestBaseClass):
             '''.format(var=var, operation=operation)
 
     @pytest.mark.parametrize('id', ['oelint.append.protvars'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('var', [
             "PV",
             "PR",
@@ -24,16 +24,16 @@ class TestClassOelintAppendProtVars(TestBaseClass):
             "LIC_FILES_CHKSUM"
     ])
     @pytest.mark.parametrize('operation', ['=', ':='])
-    def test_bad(self, id, occurance, var, operation):
+    def test_bad(self, id, occurrence, var, operation):
         input = {
             'oelint_adv_test.bbappend': self.__generate_sample_code(var, operation)
         }
         id += '.{}'.format(var)
-        self.check_for_id(self._create_args(input), id, occurance)
+        self.check_for_id(self._create_args(input), id, occurrence)
 
 
     @pytest.mark.parametrize('id', ['oelint.append.protvars'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('var', [
             "PV",
             "PR",
@@ -42,15 +42,15 @@ class TestClassOelintAppendProtVars(TestBaseClass):
             "LIC_FILES_CHKSUM"
     ])
     @pytest.mark.parametrize('operation', ['?=', '??='])
-    def test_good_weak(self, id, occurance, var, operation):
+    def test_good_weak(self, id, occurrence, var, operation):
         input = {
             'oelint_adv_test.bbappend': self.__generate_sample_code(var, operation)
         }
         id += '.{}'.format(var)
-        self.check_for_id(self._create_args(input), id, occurance)
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.append.protvars'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('var', [
             "PV",
             "PR",
@@ -59,15 +59,15 @@ class TestClassOelintAppendProtVars(TestBaseClass):
             "LIC_FILES_CHKSUM"
     ])
     @pytest.mark.parametrize('operation', ['=', ':='])
-    def test_good_bb(self, id, occurance, var, operation):
+    def test_good_bb(self, id, occurrence, var, operation):
         input = {
             'oelint_adv_test.bb': self.__generate_sample_code(var, operation)
         }
         id += '.{}'.format(var)
-        self.check_for_id(self._create_args(input), id, occurance)
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.append.protvars'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('var', [
             "PV[vardeps]",
             "PV[vardepsexclude]",
@@ -75,9 +75,9 @@ class TestClassOelintAppendProtVars(TestBaseClass):
             "PV[vardepvalueexclude]",
     ])
     @pytest.mark.parametrize('operation', ['=', ':='])
-    def test_good_flags(self, id, occurance, var, operation):
+    def test_good_flags(self, id, occurrence, var, operation):
         input = {
             'oelint_adv_test.bbappend': self.__generate_sample_code(var, operation)
         }
         id += '.{}'.format(var)
-        self.check_for_id(self._create_args(input), id, occurance)
+        self.check_for_id(self._create_args(input), id, occurrence)

--- a/tests/test_class_oelint_file_inappmsg.py
+++ b/tests/test_class_oelint_file_inappmsg.py
@@ -10,7 +10,7 @@ from base import TestBaseClass
 class TestClassOelintFileUpstreamStatusInAppMsg(TestBaseClass):
 
     @pytest.mark.parametrize('id', ['oelint.file.inappropriatemsg'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -45,11 +45,11 @@ class TestClassOelintFileUpstreamStatusInAppMsg(TestBaseClass):
             },
         ],
     )
-    def test_bad(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_bad(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.file.inappropriatemsg'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -194,6 +194,6 @@ class TestClassOelintFileUpstreamStatusInAppMsg(TestBaseClass):
             },
         ],
     )
-    def test_good(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_good(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)
 

--- a/tests/test_class_oelint_file_includenotfound.py
+++ b/tests/test_class_oelint_file_includenotfound.py
@@ -10,7 +10,7 @@ from base import TestBaseClass
 class TestClassOelintFileIncludeNotFound(TestBaseClass):
 
     @pytest.mark.parametrize('id', ['oelint.file.includenotfound'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -21,11 +21,11 @@ class TestClassOelintFileIncludeNotFound(TestBaseClass):
             }
         ],
     )
-    def test_bad(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_bad(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.file.includenotfound'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -41,5 +41,5 @@ class TestClassOelintFileIncludeNotFound(TestBaseClass):
             }
         ],
     )
-    def test_good(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_good(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)

--- a/tests/test_class_oelint_file_nospaces.py
+++ b/tests/test_class_oelint_file_nospaces.py
@@ -10,7 +10,7 @@ from base import TestBaseClass
 class TestClassOelintFileNoSpaces(TestBaseClass):
 
     @pytest.mark.parametrize('id', ['oelint.file.nospaces'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -21,5 +21,5 @@ class TestClassOelintFileNoSpaces(TestBaseClass):
             }
         ],
     )
-    def test_bad(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_bad(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)

--- a/tests/test_class_oelint_file_patchsignedoff.py
+++ b/tests/test_class_oelint_file_patchsignedoff.py
@@ -10,7 +10,7 @@ from base import TestBaseClass
 class TestClassOelintFilePatchSignedOff(TestBaseClass):
 
     @pytest.mark.parametrize('id', ['oelint.file.patchsignedoff'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -25,11 +25,11 @@ class TestClassOelintFilePatchSignedOff(TestBaseClass):
             },
         ],
     )
-    def test_bad(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_bad(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.file.patchsignedoff'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -44,6 +44,6 @@ class TestClassOelintFilePatchSignedOff(TestBaseClass):
             }
         ],
     )
-    def test_good(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_good(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)
 

--- a/tests/test_class_oelint_file_requireinclude.py
+++ b/tests/test_class_oelint_file_requireinclude.py
@@ -10,7 +10,7 @@ from base import TestBaseClass
 class TestClassOelintFileRequireInclude(TestBaseClass):
 
     @pytest.mark.parametrize('id', ['oelint.file.requireinclude'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -21,11 +21,11 @@ class TestClassOelintFileRequireInclude(TestBaseClass):
             }
         ],
     )
-    def test_bad(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_bad(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.file.requireinclude'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -36,5 +36,5 @@ class TestClassOelintFileRequireInclude(TestBaseClass):
             }
         ],
     )
-    def test_good(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_good(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)

--- a/tests/test_class_oelint_file_requirenotfound.py
+++ b/tests/test_class_oelint_file_requirenotfound.py
@@ -10,7 +10,7 @@ from base import TestBaseClass
 class TestClassOelintRequireNotFound(TestBaseClass):
 
     @pytest.mark.parametrize('id', ['oelint.file.requirenotfound'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -21,11 +21,11 @@ class TestClassOelintRequireNotFound(TestBaseClass):
             }
         ],
     )
-    def test_bad(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_bad(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.file.requirenotfound'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -41,5 +41,5 @@ class TestClassOelintRequireNotFound(TestBaseClass):
             }
         ],
     )
-    def test_good(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_good(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)

--- a/tests/test_class_oelint_file_underscores.py
+++ b/tests/test_class_oelint_file_underscores.py
@@ -10,7 +10,7 @@ from base import TestBaseClass
 class TestClassOelintFileUnderscores(TestBaseClass):
 
     @pytest.mark.parametrize('id', ['oelint.file.underscores'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -33,11 +33,11 @@ class TestClassOelintFileUnderscores(TestBaseClass):
             }
         ],
     )
-    def test_bad(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_bad(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.file.underscores'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -72,6 +72,6 @@ class TestClassOelintFileUnderscores(TestBaseClass):
             },
         ],
     )
-    def test_good(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_good(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)
 

--- a/tests/test_class_oelint_file_upstreamstatus.py
+++ b/tests/test_class_oelint_file_upstreamstatus.py
@@ -10,7 +10,7 @@ from base import TestBaseClass
 class TestClassOelintFileUpstreamStatus(TestBaseClass):
 
     @pytest.mark.parametrize('id', ['oelint.file.upstreamstatus'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -55,12 +55,12 @@ class TestClassOelintFileUpstreamStatus(TestBaseClass):
             },
         ],
     )
-    def test_bad(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_bad(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)
 
 
     @pytest.mark.parametrize('id', ['oelint.file.upstreamstatus'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -215,6 +215,6 @@ class TestClassOelintFileUpstreamStatus(TestBaseClass):
             },
         ],
     )
-    def test_good(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_good(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)
 

--- a/tests/test_class_oelint_func_specific.py
+++ b/tests/test_class_oelint_func_specific.py
@@ -10,7 +10,7 @@ from base import TestBaseClass
 class TestClassOelintFuncSpecific(TestBaseClass):
 
     @pytest.mark.parametrize('id', ['oelint.func.specific'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -50,11 +50,11 @@ class TestClassOelintFuncSpecific(TestBaseClass):
             
         ],
     )
-    def test_bad(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_bad(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.func.specific'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -105,6 +105,6 @@ class TestClassOelintFuncSpecific(TestBaseClass):
             },
         ],
     )
-    def test_good(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_good(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)
 

--- a/tests/test_class_oelint_jetm_vars_dependssingleline.py
+++ b/tests/test_class_oelint_jetm_vars_dependssingleline.py
@@ -10,7 +10,7 @@ from base import TestBaseClass
 class TestClassOelintJetmDependsSingleLine(TestBaseClass):
 
     @pytest.mark.parametrize('id', ['oelint.jetm.vars.dependssingleline'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -48,11 +48,11 @@ class TestClassOelintJetmDependsSingleLine(TestBaseClass):
             },
         ],
     )
-    def test_bad(self, input, id, occurance):
-        self.check_for_id(self._create_args(input, extraopts=["--addrules=jetm"]), id, occurance)
+    def test_bad(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input, extraopts=["--addrules=jetm"]), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.jetm.vars.dependssingleline'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -82,11 +82,11 @@ class TestClassOelintJetmDependsSingleLine(TestBaseClass):
             },
         ],
     )
-    def test_good(self, input, id, occurance):
-        self.check_for_id(self._create_args(input, extraopts=["--addrules=jetm"]), id, occurance)
+    def test_good(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input, extraopts=["--addrules=jetm"]), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.jetm.vars.dependssingleline'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -117,5 +117,5 @@ class TestClassOelintJetmDependsSingleLine(TestBaseClass):
             },
         ],
     )
-    def test_good_module_off(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_good_module_off(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)

--- a/tests/test_class_oelint_newline_consecutive.py
+++ b/tests/test_class_oelint_newline_consecutive.py
@@ -10,7 +10,7 @@ from base import TestBaseClass
 class TestClassOelintNewlineConsecutive(TestBaseClass):
 
     @pytest.mark.parametrize('id', ['oelint.newline.consecutive'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -24,8 +24,8 @@ class TestClassOelintNewlineConsecutive(TestBaseClass):
             }
         ],
     )
-    def test_bad(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_bad(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.newline.consecutive'])
     @pytest.mark.parametrize('input', 
@@ -45,7 +45,7 @@ class TestClassOelintNewlineConsecutive(TestBaseClass):
         self.fix_and_check(self._create_args_fix(input), id)
 
     @pytest.mark.parametrize('id', ['oelint.newline.consecutive'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -61,5 +61,5 @@ class TestClassOelintNewlineConsecutive(TestBaseClass):
             }
         ],
     )
-    def test_good(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_good(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)

--- a/tests/test_class_oelint_newline_eof.py
+++ b/tests/test_class_oelint_newline_eof.py
@@ -10,7 +10,7 @@ from base import TestBaseClass
 class TestClassOelintNewlineEOF(TestBaseClass):
 
     @pytest.mark.parametrize('id', ['oelint.newline.eof'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -20,8 +20,8 @@ class TestClassOelintNewlineEOF(TestBaseClass):
             }
         ],
     )
-    def test_bad(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_bad(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.newline.eof'])
     @pytest.mark.parametrize('input', 
@@ -37,7 +37,7 @@ class TestClassOelintNewlineEOF(TestBaseClass):
         self.fix_and_check(self._create_args_fix(input), id)
 
     @pytest.mark.parametrize('id', ['oelint.newline.eof'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -48,5 +48,5 @@ class TestClassOelintNewlineEOF(TestBaseClass):
             }
         ],
     )
-    def test_good(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_good(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)

--- a/tests/test_class_oelint_spaces_emptyline.py
+++ b/tests/test_class_oelint_spaces_emptyline.py
@@ -9,7 +9,7 @@ from base import TestBaseClass
 
 class TestClassOelintSpacesEmptyLine(TestBaseClass):
     @pytest.mark.parametrize('id', ['oelint.spaces.emptyline'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -22,5 +22,5 @@ class TestClassOelintSpacesEmptyLine(TestBaseClass):
             }
         ],
     )
-    def test_good(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_good(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)

--- a/tests/test_class_oelint_spaces_linebeginning.py
+++ b/tests/test_class_oelint_spaces_linebeginning.py
@@ -10,7 +10,7 @@ from base import TestBaseClass
 class TestClassOelintSpacesLineBeginning(TestBaseClass):
 
     @pytest.mark.parametrize('id', ['oelint.spaces.linebeginning'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -29,8 +29,8 @@ class TestClassOelintSpacesLineBeginning(TestBaseClass):
             }
         ],
     )
-    def test_bad(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_bad(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.spaces.linebeginning'])
     @pytest.mark.parametrize('input', 
@@ -70,7 +70,7 @@ class TestClassOelintSpacesLineBeginning(TestBaseClass):
         self.fix_and_check(self._create_args_fix(input), id)
 
     @pytest.mark.parametrize('id', ['oelint.spaces.linebeginning'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -96,5 +96,5 @@ class TestClassOelintSpacesLineBeginning(TestBaseClass):
             }
         ],
     )
-    def test_good(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_good(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)

--- a/tests/test_class_oelint_spaces_linecont.py
+++ b/tests/test_class_oelint_spaces_linecont.py
@@ -10,7 +10,7 @@ from base import TestBaseClass
 class TestClassOelintSpacesLineCont(TestBaseClass):
 
     @pytest.mark.parametrize('id', ['oelint.spaces.linecont'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -32,8 +32,8 @@ class TestClassOelintSpacesLineCont(TestBaseClass):
             }
         ],
     )
-    def test_bad(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_bad(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.spaces.linecont'])
     @pytest.mark.parametrize('input', 
@@ -61,7 +61,7 @@ class TestClassOelintSpacesLineCont(TestBaseClass):
         self.fix_and_check(self._create_args_fix(input), id)
 
     @pytest.mark.parametrize('id', ['oelint.spaces.linecont'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -90,5 +90,5 @@ class TestClassOelintSpacesLineCont(TestBaseClass):
             }
         ],
     )
-    def test_good(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_good(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)

--- a/tests/test_class_oelint_spaces_lineend.py
+++ b/tests/test_class_oelint_spaces_lineend.py
@@ -10,7 +10,7 @@ from base import TestBaseClass
 class TestClassOelintSpacesLineEnd(TestBaseClass):
 
     @pytest.mark.parametrize('id', ['oelint.spaces.lineend'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -27,8 +27,8 @@ class TestClassOelintSpacesLineEnd(TestBaseClass):
             }
         ],
     )
-    def test_bad(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_bad(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.spaces.lineend'])
     @pytest.mark.parametrize('input', 
@@ -58,7 +58,7 @@ class TestClassOelintSpacesLineEnd(TestBaseClass):
         self.fix_and_check(self._create_args_fix(input), id)
 
     @pytest.mark.parametrize('id', ['oelint.spaces.lineend'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -75,5 +75,5 @@ class TestClassOelintSpacesLineEnd(TestBaseClass):
             }
         ],
     )
-    def test_good(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_good(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)

--- a/tests/test_class_oelint_task_addnotaskbody.py
+++ b/tests/test_class_oelint_task_addnotaskbody.py
@@ -10,7 +10,7 @@ from base import TestBaseClass
 class TestClassOelintTaskAddNoBody(TestBaseClass):
 
     @pytest.mark.parametrize('id', ['oelint.task.addnotaskbody'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -39,11 +39,11 @@ class TestClassOelintTaskAddNoBody(TestBaseClass):
             }
         ],
     )
-    def test_bad(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_bad(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.task.addnotaskbody'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -90,5 +90,5 @@ class TestClassOelintTaskAddNoBody(TestBaseClass):
             }
         ],
     )
-    def test_good(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_good(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)

--- a/tests/test_class_oelint_task_anonpython.py
+++ b/tests/test_class_oelint_task_anonpython.py
@@ -10,7 +10,7 @@ from base import TestBaseClass
 class TestClassOelintTaskNoAnonPython(TestBaseClass):
 
     @pytest.mark.parametrize('id', ['oelint.task.noanonpython'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -39,11 +39,11 @@ class TestClassOelintTaskNoAnonPython(TestBaseClass):
             }
         ],
     )
-    def test_bad(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_bad(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.task.noanonpython'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -65,5 +65,5 @@ class TestClassOelintTaskNoAnonPython(TestBaseClass):
             },
         ],
     )
-    def test_good(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_good(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)

--- a/tests/test_class_oelint_task_customorder.py
+++ b/tests/test_class_oelint_task_customorder.py
@@ -10,7 +10,7 @@ from base import TestBaseClass
 class TestClassOelintTaskCustomOrder(TestBaseClass):
 
     @pytest.mark.parametrize('id', ['oelint.task.customorder'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -32,11 +32,11 @@ class TestClassOelintTaskCustomOrder(TestBaseClass):
             },
         ],
     )
-    def test_bad(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_bad(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.task.customorder'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -48,5 +48,5 @@ class TestClassOelintTaskCustomOrder(TestBaseClass):
             },
         ],
     )
-    def test_good(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_good(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)

--- a/tests/test_class_oelint_task_docstrings.py
+++ b/tests/test_class_oelint_task_docstrings.py
@@ -10,7 +10,7 @@ from base import TestBaseClass
 class TestClassOelintTaskDocstrings(TestBaseClass):
 
     @pytest.mark.parametrize('id', ['oelint.task.docstrings'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -24,11 +24,11 @@ class TestClassOelintTaskDocstrings(TestBaseClass):
             },
         ],
     )
-    def test_bad(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_bad(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.task.docstrings'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -53,5 +53,5 @@ class TestClassOelintTaskDocstrings(TestBaseClass):
             },
         ],
     )
-    def test_good(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_good(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)

--- a/tests/test_class_oelint_task_heredocs.py
+++ b/tests/test_class_oelint_task_heredocs.py
@@ -10,7 +10,7 @@ from base import TestBaseClass
 class TestClassOelintTaskHeredocs(TestBaseClass):
 
     @pytest.mark.parametrize('id', ['oelint.task.heredocs'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -35,11 +35,11 @@ class TestClassOelintTaskHeredocs(TestBaseClass):
             },
         ],
     )
-    def test_bad(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_bad(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.task.heredocs'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -52,5 +52,5 @@ class TestClassOelintTaskHeredocs(TestBaseClass):
             }
         ],
     )
-    def test_good(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_good(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)

--- a/tests/test_class_oelint_task_multifragments.py
+++ b/tests/test_class_oelint_task_multifragments.py
@@ -10,7 +10,7 @@ from base import TestBaseClass
 class TestClassOelintTaskMultiAppends(TestBaseClass):
 
     @pytest.mark.parametrize('id', ['oelint.task.multifragments'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -48,11 +48,11 @@ class TestClassOelintTaskMultiAppends(TestBaseClass):
             },
         ],
     )
-    def test_bad(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_bad(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.task.multifragments'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -123,5 +123,5 @@ class TestClassOelintTaskMultiAppends(TestBaseClass):
             }
         ],
     )
-    def test_good(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_good(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)

--- a/tests/test_class_oelint_task_nocp.py
+++ b/tests/test_class_oelint_task_nocp.py
@@ -10,7 +10,7 @@ from base import TestBaseClass
 class TestClassOelintTaskNoCopy(TestBaseClass):
 
     @pytest.mark.parametrize('id', ['oelint.task.nocopy'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -31,11 +31,11 @@ class TestClassOelintTaskNoCopy(TestBaseClass):
             },
         ],
     )
-    def test_bad(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_bad(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.task.nocopy'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -48,5 +48,5 @@ class TestClassOelintTaskNoCopy(TestBaseClass):
             },
         ],
     )
-    def test_good(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_good(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)

--- a/tests/test_class_oelint_task_nomkdir.py
+++ b/tests/test_class_oelint_task_nomkdir.py
@@ -10,7 +10,7 @@ from base import TestBaseClass
 class TestClassOelintTaskNoMkdir(TestBaseClass):
 
     @pytest.mark.parametrize('id', ['oelint.task.nomkdir'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -31,11 +31,11 @@ class TestClassOelintTaskNoMkdir(TestBaseClass):
             },
         ],
     )
-    def test_bad(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_bad(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.task.nomkdir'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -56,5 +56,5 @@ class TestClassOelintTaskNoMkdir(TestBaseClass):
             },
         ],
     )
-    def test_good(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_good(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)

--- a/tests/test_class_oelint_task_nopythonprefix.py
+++ b/tests/test_class_oelint_task_nopythonprefix.py
@@ -10,7 +10,7 @@ from base import TestBaseClass
 class TestClassOelintTaskNoPythonPrefix(TestBaseClass):
 
     @pytest.mark.parametrize('id', ['oelint.task.nopythonprefix'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -24,11 +24,11 @@ class TestClassOelintTaskNoPythonPrefix(TestBaseClass):
             },
         ],
     )
-    def test_bad(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_bad(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.task.nopythonprefix'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -51,5 +51,5 @@ class TestClassOelintTaskNoPythonPrefix(TestBaseClass):
             },
         ],
     )
-    def test_good(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_good(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)

--- a/tests/test_class_oelint_task_pythonprefix.py
+++ b/tests/test_class_oelint_task_pythonprefix.py
@@ -10,7 +10,7 @@ from base import TestBaseClass
 class TestClassOelintTaskPythonPrefix(TestBaseClass):
 
     @pytest.mark.parametrize('id', ['oelint.task.pythonprefix'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -24,11 +24,11 @@ class TestClassOelintTaskPythonPrefix(TestBaseClass):
             },
         ],
     )
-    def test_bad(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_bad(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.task.pythonprefix'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -51,5 +51,5 @@ class TestClassOelintTaskPythonPrefix(TestBaseClass):
             },
         ],
     )
-    def test_good(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_good(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)

--- a/tests/test_class_oelint_task_taskorder.py
+++ b/tests/test_class_oelint_task_taskorder.py
@@ -31,7 +31,7 @@ class TestClassOelintTaskOrder(TestBaseClass):
             '''.format(first=first, second=second)
 
     @pytest.mark.parametrize('id', ['oelint.task.order.do_fetch'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('pair', [
         ("do_unpack", "do_fetch"),
         ("do_patch", "do_fetch"),
@@ -42,14 +42,14 @@ class TestClassOelintTaskOrder(TestBaseClass):
         ("do_build", "do_fetch"),
         ("do_package", "do_fetch"),
     ])
-    def test_bad_fetch(self, id, occurance, pair):
+    def test_bad_fetch(self, id, occurrence, pair):
         input = {
             'oelint_adv_test.bb': self.__generate_sample_code(pair[0], pair[1])
         }
-        self.check_for_id(self._create_args(input), id, occurance)
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.task.order.do_unpack'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('pair', [
         ("do_patch", "do_unpack"),
         ("do_configure", "do_unpack"),
@@ -59,14 +59,14 @@ class TestClassOelintTaskOrder(TestBaseClass):
         ("do_build", "do_unpack"),
         ("do_package", "do_unpack"),
     ])
-    def test_bad_unpack(self, id, occurance, pair):
+    def test_bad_unpack(self, id, occurrence, pair):
         input = {
             'oelint_adv_test.bb': self.__generate_sample_code(pair[0], pair[1])
         }
-        self.check_for_id(self._create_args(input), id, occurance)
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.task.order.do_patch'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('pair', [
         ("do_configure", "do_patch"),
         ("do_compile", "do_patch"),
@@ -75,14 +75,14 @@ class TestClassOelintTaskOrder(TestBaseClass):
         ("do_build", "do_patch"),
         ("do_package", "do_patch"),
     ])
-    def test_bad_patch(self, id, occurance, pair):
+    def test_bad_patch(self, id, occurrence, pair):
         input = {
             'oelint_adv_test.bb': self.__generate_sample_code(pair[0], pair[1])
         }
-        self.check_for_id(self._create_args(input), id, occurance)
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.task.order.do_configure'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('pair', [
         ("do_compile", "do_configure"),
         ("do_install", "do_configure"),
@@ -90,14 +90,14 @@ class TestClassOelintTaskOrder(TestBaseClass):
         ("do_build", "do_configure"),
         ("do_package", "do_configure"),
     ])
-    def test_bad_configure(self, id, occurance, pair):
+    def test_bad_configure(self, id, occurrence, pair):
         input = {
             'oelint_adv_test.bb': self.__generate_sample_code(pair[0], pair[1])
         }
-        self.check_for_id(self._create_args(input), id, occurance)
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.task.order.do_compile'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('pair', [
         ("do_install", "do_compile"),
         ("do_populate_sysroot", "do_compile"),
@@ -105,52 +105,52 @@ class TestClassOelintTaskOrder(TestBaseClass):
         ("do_install", "do_compile"),
         ("do_package", "do_compile"),
     ])
-    def test_bad_compile(self, id, occurance, pair):
+    def test_bad_compile(self, id, occurrence, pair):
         input = {
             'oelint_adv_test.bb': self.__generate_sample_code(pair[0], pair[1])
         }
-        self.check_for_id(self._create_args(input), id, occurance)
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.task.order.do_install'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('pair', [
         ("do_populate_sysroot", "do_install"),
         ("do_build", "do_install"),
         ("do_package", "do_install"),
     ])
-    def test_bad_install(self, id, occurance, pair):
+    def test_bad_install(self, id, occurrence, pair):
         input = {
             'oelint_adv_test.bb': self.__generate_sample_code(pair[0], pair[1])
         }
-        self.check_for_id(self._create_args(input), id, occurance)
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.task.order.do_populate_sysroot'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('pair', [
         ("do_build", "do_populate_sysroot"),
         ("do_package", "do_populate_sysroot"),
     ])
-    def test_bad_populate_sysroot(self, id, occurance, pair):
+    def test_bad_populate_sysroot(self, id, occurrence, pair):
         input = {
             'oelint_adv_test.bb': self.__generate_sample_code(pair[0], pair[1])
         }
-        self.check_for_id(self._create_args(input), id, occurance)
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.task.order.do_build'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('pair', [
         ("do_package", "do_build"),
     ])
-    def test_bad_build(self, id, occurance, pair):
+    def test_bad_build(self, id, occurrence, pair):
         input = {
             'oelint_adv_test.bb': self.__generate_sample_code(pair[0], pair[1])
         }
-        self.check_for_id(self._create_args(input), id, occurance)
+        self.check_for_id(self._create_args(input), id, occurrence)
 
 ####
 
     @pytest.mark.parametrize('id', ['oelint.task.order.do_fetch'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('pair', [
         ("do_fetch", "do_unpack"),
         ("do_fetch", "do_patch"),
@@ -161,14 +161,14 @@ class TestClassOelintTaskOrder(TestBaseClass):
         ("do_fetch", "do_build"),
         ("do_fetch", "do_package"),
     ])
-    def test_good_fetch(self, id, occurance, pair):
+    def test_good_fetch(self, id, occurrence, pair):
         input = {
             'oelint_adv_test.bb': self.__generate_sample_code(pair[0], pair[1])
         }
-        self.check_for_id(self._create_args(input), id, occurance)
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.task.order.do_unpack'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('pair', [
         ("do_unpack", "do_patch"),
         ("do_unpack", "do_configure"),
@@ -178,14 +178,14 @@ class TestClassOelintTaskOrder(TestBaseClass):
         ("do_unpack", "do_build"),
         ("do_unpack", "do_package"),
     ])
-    def test_good_unpack(self, id, occurance, pair):
+    def test_good_unpack(self, id, occurrence, pair):
         input = {
             'oelint_adv_test.bb': self.__generate_sample_code(pair[0], pair[1])
         }
-        self.check_for_id(self._create_args(input), id, occurance)
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.task.order.do_patch'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('pair', [
         ("do_patch", "do_configure"),
         ("do_patch", "do_compile"),
@@ -194,14 +194,14 @@ class TestClassOelintTaskOrder(TestBaseClass):
         ("do_patch", "do_build"),
         ("do_patch", "do_package"),
     ])
-    def test_good_patch(self, id, occurance, pair):
+    def test_good_patch(self, id, occurrence, pair):
         input = {
             'oelint_adv_test.bb': self.__generate_sample_code(pair[0], pair[1])
         }
-        self.check_for_id(self._create_args(input), id, occurance)
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.task.order.do_configure'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('pair', [
         ("do_configure", "do_compile"),
         ("do_configure", "do_install"),
@@ -209,14 +209,14 @@ class TestClassOelintTaskOrder(TestBaseClass):
         ("do_configure", "do_build"),
         ("do_configure", "do_package"),
     ])
-    def test_good_configure(self, id, occurance, pair):
+    def test_good_configure(self, id, occurrence, pair):
         input = {
             'oelint_adv_test.bb': self.__generate_sample_code(pair[0], pair[1])
         }
-        self.check_for_id(self._create_args(input), id, occurance)
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.task.order.do_compile'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('pair', [
         ("do_compile", "do_install"),
         ("do_compile", "do_populate_sysroot"),
@@ -224,50 +224,50 @@ class TestClassOelintTaskOrder(TestBaseClass):
         ("do_compile", "do_install"),
         ("do_compile", "do_package"),
     ])
-    def test_good_compile(self, id, occurance, pair):
+    def test_good_compile(self, id, occurrence, pair):
         input = {
             'oelint_adv_test.bb': self.__generate_sample_code(pair[0], pair[1])
         }
-        self.check_for_id(self._create_args(input), id, occurance)
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.task.order.do_install'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('pair', [
         ("do_install", "do_populate_sysroot"),
         ("do_install", "do_build"),
         ("do_install", "do_package"),
     ])
-    def test_good_install(self, id, occurance, pair):
+    def test_good_install(self, id, occurrence, pair):
         input = {
             'oelint_adv_test.bb': self.__generate_sample_code(pair[0], pair[1])
         }
-        self.check_for_id(self._create_args(input), id, occurance)
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.task.order.do_populate_sysroot'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('pair', [
         ("do_populate_sysroot", "do_build"),
         ("do_populate_sysroot", "do_package"),
     ])
-    def test_good_populate_sysroot(self, id, occurance, pair):
+    def test_good_populate_sysroot(self, id, occurrence, pair):
         input = {
             'oelint_adv_test.bb': self.__generate_sample_code(pair[0], pair[1])
         }
-        self.check_for_id(self._create_args(input), id, occurance)
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.task.order.do_build'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('pair', [
         ("do_build", "do_package"),
     ])
-    def test_good_build(self, id, occurance, pair):
+    def test_good_build(self, id, occurrence, pair):
         input = {
             'oelint_adv_test.bb': self.__generate_sample_code(pair[0], pair[1])
         }
-        self.check_for_id(self._create_args(input), id, occurance)
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.task.order.do_build'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('input', 
         [
                         {
@@ -283,11 +283,11 @@ class TestClassOelintTaskOrder(TestBaseClass):
             },
         ],
     )
-    def test_good_pattern(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_good_pattern(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.task.order.do_build'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('input',
         [
             {
@@ -310,5 +310,5 @@ class TestClassOelintTaskOrder(TestBaseClass):
             }
         ],
     )
-    def test_single_file_scope(self, id, occurance, input):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_single_file_scope(self, id, occurrence, input):
+        self.check_for_id(self._create_args(input), id, occurrence)

--- a/tests/test_class_oelint_var_bbclassextend.py
+++ b/tests/test_class_oelint_var_bbclassextend.py
@@ -10,7 +10,7 @@ from base import TestBaseClass
 class TestClassOelintVarBBClassExtend(TestBaseClass):
 
     @pytest.mark.parametrize('id', ['oelint.var.bbclassextend'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -21,11 +21,11 @@ class TestClassOelintVarBBClassExtend(TestBaseClass):
             },
         ],
     )
-    def test_bad(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_bad(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.var.bbclassextend'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('input', 
         [
                         {
@@ -42,5 +42,5 @@ class TestClassOelintVarBBClassExtend(TestBaseClass):
             },
         ],
     )
-    def test_good(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_good(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)

--- a/tests/test_class_oelint_var_filesoverride.py
+++ b/tests/test_class_oelint_var_filesoverride.py
@@ -10,7 +10,7 @@ from base import TestBaseClass
 class TestClassOelintVarFilesOverride(TestBaseClass):
 
     @pytest.mark.parametrize('id', ['oelint.var.filesoverride'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -39,11 +39,11 @@ class TestClassOelintVarFilesOverride(TestBaseClass):
             },
         ],
     )
-    def test_bad(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_bad(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.var.filesoverride'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -114,5 +114,5 @@ class TestClassOelintVarFilesOverride(TestBaseClass):
             },
         ],
     )
-    def test_good(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_good(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)

--- a/tests/test_class_oelint_var_improperinherit.py
+++ b/tests/test_class_oelint_var_improperinherit.py
@@ -10,7 +10,7 @@ from base import TestBaseClass
 class TestClassOelintVarImproperInherit(TestBaseClass):
 
     @pytest.mark.parametrize('id', ['oelint.var.improperinherit'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -33,11 +33,11 @@ class TestClassOelintVarImproperInherit(TestBaseClass):
             },
         ],
     )
-    def test_bad(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_bad(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.var.improperinherit'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -73,5 +73,5 @@ class TestClassOelintVarImproperInherit(TestBaseClass):
             },
         ],
     )
-    def test_good(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_good(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)

--- a/tests/test_class_oelint_var_licenseremote.py
+++ b/tests/test_class_oelint_var_licenseremote.py
@@ -10,7 +10,7 @@ from base import TestBaseClass
 class TestClassOelintVarLicenseRemoteFile(TestBaseClass):
 
     @pytest.mark.parametrize('id', ['oelint.var.licenseremotefile'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -28,11 +28,11 @@ class TestClassOelintVarLicenseRemoteFile(TestBaseClass):
             }
         ],
     )
-    def test_bad(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_bad(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.var.licenseremotefile'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -68,5 +68,5 @@ class TestClassOelintVarLicenseRemoteFile(TestBaseClass):
             },
         ],
     )
-    def test_good(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_good(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)

--- a/tests/test_class_oelint_var_mandatory.py
+++ b/tests/test_class_oelint_var_mandatory.py
@@ -16,7 +16,7 @@ class TestClassOelintVarMandatoryVar(TestBaseClass):
             '''.format(var=var, extra=extra)
 
     @pytest.mark.parametrize('id', ['oelint.var.mandatoryvar'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('var', [
         "SUMMARY",
         "DESCRIPTION",
@@ -24,15 +24,15 @@ class TestClassOelintVarMandatoryVar(TestBaseClass):
         "LICENSE",
         "SRC_URI"
     ])
-    def test_bad(self, id, occurance, var):
+    def test_bad(self, id, occurrence, var):
         input = {
             'oelint_adv_test.bb': self.__generate_sample_code('A', '')
         }
         id += '.{}'.format(var)
-        self.check_for_id(self._create_args(input), id, occurance)
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.var.mandatoryvar'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('var', [
         "SUMMARY",
         "DESCRIPTION",
@@ -45,12 +45,12 @@ class TestClassOelintVarMandatoryVar(TestBaseClass):
         'IMAGE_INSTALL += " foo"',
         'IMAGE_INSTALL = "foo"'
     ])
-    def test_bad_image(self, id, occurance, var, extra):
+    def test_bad_image(self, id, occurrence, var, extra):
         input = {
             'oelint_adv_test.bb': self.__generate_sample_code('A', extra)
         }
         id += '.{}'.format(var)
-        self.check_for_id(self._create_args(input), id, occurance)
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', [
         'oelint.var.mandatoryvar.SUMMARY',
@@ -59,7 +59,7 @@ class TestClassOelintVarMandatoryVar(TestBaseClass):
         'oelint.var.mandatoryvar.LICENSE',
         'oelint.var.mandatoryvar.SRC_URI',
         ])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -100,8 +100,8 @@ class TestClassOelintVarMandatoryVar(TestBaseClass):
             },
         ],
     )
-    def test_good(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_good(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)
 
 
  

--- a/tests/test_class_oelint_var_multiinclude.py
+++ b/tests/test_class_oelint_var_multiinclude.py
@@ -10,7 +10,7 @@ from base import TestBaseClass
 class TestClassOelintVarMultiInclude(TestBaseClass):
 
     @pytest.mark.parametrize('id', ['oelint.var.multiinclude'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -31,11 +31,11 @@ class TestClassOelintVarMultiInclude(TestBaseClass):
             },
         ],
     )
-    def test_bad(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_bad(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.var.multiinclude'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -48,5 +48,5 @@ class TestClassOelintVarMultiInclude(TestBaseClass):
             },
         ],
     )
-    def test_good(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_good(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)

--- a/tests/test_class_oelint_var_multiinherit.py
+++ b/tests/test_class_oelint_var_multiinherit.py
@@ -10,7 +10,7 @@ from base import TestBaseClass
 class TestClassOelintVarMultiInherit(TestBaseClass):
 
     @pytest.mark.parametrize('id', ['oelint.var.multiinherit'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -28,11 +28,11 @@ class TestClassOelintVarMultiInherit(TestBaseClass):
             },
         ],
     )
-    def test_bad(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_bad(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.var.multiinherit'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -46,5 +46,5 @@ class TestClassOelintVarMultiInherit(TestBaseClass):
             },
         ],
     )
-    def test_good(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_good(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)

--- a/tests/test_class_oelint_var_nativefilename.py
+++ b/tests/test_class_oelint_var_nativefilename.py
@@ -10,7 +10,7 @@ from base import TestBaseClass
 class TestClassOelintVarNativeFilename(TestBaseClass):
 
     @pytest.mark.parametrize('id', ['oelint.var.nativefilename'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -21,11 +21,11 @@ class TestClassOelintVarNativeFilename(TestBaseClass):
             }
         ],
     )
-    def test_bad(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_bad(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.var.nativefilename'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -36,5 +36,5 @@ class TestClassOelintVarNativeFilename(TestBaseClass):
             },
         ],
     )
-    def test_good(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_good(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)

--- a/tests/test_class_oelint_var_order.py
+++ b/tests/test_class_oelint_var_order.py
@@ -46,36 +46,36 @@ class TestClassOelintVarOrder(TestBaseClass):
             '''.format(first=first, second=second)
 
     @pytest.mark.parametrize('id', ['oelint.var.order'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('var', VAR_ORDER)
-    def test_bad(self, id, occurance, var):
+    def test_bad(self, id, occurrence, var):
         try:
             id += '.{}'.format(var)
             for item in VAR_ORDER[:VAR_ORDER.index(var)]:
                 input = {
                     'oelint_adv_test.bb': self.__generate_sample_code(item, var)
                 }
-                self.check_for_id(self._create_args(input), id, occurance)
+                self.check_for_id(self._create_args(input), id, occurrence)
         except:
             pass
 
     @pytest.mark.parametrize('id', ['oelint.var.order'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('var', VAR_ORDER)
-    def test_good(self, id, occurance, var):
+    def test_good(self, id, occurrence, var):
         try:
             id += '.{}'.format(var)
             for item in VAR_ORDER[VAR_ORDER.index(var):]:
                 input = {
                     'oelint_adv_test.bb': self.__generate_sample_code(item, var)
                 }
-                self.check_for_id(self._create_args(input), id, occurance)
+                self.check_for_id(self._create_args(input), id, occurrence)
         except:
             pass
 
 
     @pytest.mark.parametrize('id', ['oelint.var.order.SRCREV'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('input',
         [
             {
@@ -96,5 +96,5 @@ class TestClassOelintVarOrder(TestBaseClass):
             }
         ],
     )
-    def test_single_file_scope(self, id, occurance, input):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_single_file_scope(self, id, occurrence, input):
+        self.check_for_id(self._create_args(input), id, occurrence)

--- a/tests/test_class_oelint_var_override.py
+++ b/tests/test_class_oelint_var_override.py
@@ -10,7 +10,7 @@ from base import TestBaseClass
 class TestClassOelintVarOverride(TestBaseClass):
 
     @pytest.mark.parametrize('id', ['oelint.var.override'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -30,11 +30,11 @@ class TestClassOelintVarOverride(TestBaseClass):
             },
         ],
     )
-    def test_bad(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_bad(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.var.override'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -95,5 +95,5 @@ class TestClassOelintVarOverride(TestBaseClass):
             }
         ],
     )
-    def test_good(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_good(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)

--- a/tests/test_class_oelint_var_rootfscmd.py
+++ b/tests/test_class_oelint_var_rootfscmd.py
@@ -10,7 +10,7 @@ from base import TestBaseClass
 class TestClassOelintVarRootFSCmd(TestBaseClass):
 
     @pytest.mark.parametrize('id', ['oelint.var.rootfspostcmd'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -21,11 +21,11 @@ class TestClassOelintVarRootFSCmd(TestBaseClass):
             },
         ],
     )
-    def test_bad(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_bad(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.var.rootfspostcmd'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -36,5 +36,5 @@ class TestClassOelintVarRootFSCmd(TestBaseClass):
             },
         ],
     )
-    def test_good(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_good(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)

--- a/tests/test_class_oelint_var_suggested.py
+++ b/tests/test_class_oelint_var_suggested.py
@@ -16,7 +16,7 @@ class TestClassOelintVarSuggestedVar(TestBaseClass):
             '''.format(var=var, extra=extra)
 
     @pytest.mark.parametrize('id', ['oelint.var.suggestedvar'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('var', [
         "AUTHOR",
         "BUGTRACKER",
@@ -24,15 +24,15 @@ class TestClassOelintVarSuggestedVar(TestBaseClass):
         "CVE_PRODUCT",
         "SECTION",
     ])
-    def test_bad(self, id, occurance, var):
+    def test_bad(self, id, occurrence, var):
         input = {
             'oelint_adv_test.bb': self.__generate_sample_code('A', '')
         }
         id += '.{}'.format(var)
-        self.check_for_id(self._create_args(input), id, occurance)
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.var.suggestedvar.CVE_PRODUCT'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -43,9 +43,9 @@ class TestClassOelintVarSuggestedVar(TestBaseClass):
             },
         ]
     )
-    def test_suppress(self, id, occurance, input):
+    def test_suppress(self, id, occurrence, input):
         _x = self._create_args(input, extraopts=["--suppress", id])
-        self.check_for_id(_x, id, occurance)
+        self.check_for_id(_x, id, occurrence)
         self.check_for_id(_x, 'oelint.var.suggestedvar.BUGTRACKER', 1)
 
     @pytest.mark.parametrize('id', [
@@ -55,7 +55,7 @@ class TestClassOelintVarSuggestedVar(TestBaseClass):
         'oelint.var.suggestedvar.CVE_PRODUCT',
         'oelint.var.suggestedvar.SECTION',
         ])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -70,8 +70,8 @@ class TestClassOelintVarSuggestedVar(TestBaseClass):
             },
         ],
     )
-    def test_good(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_good(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)
 
 
  

--- a/tests/test_class_oelint_vars_appendop.py
+++ b/tests/test_class_oelint_vars_appendop.py
@@ -10,7 +10,7 @@ from base import TestBaseClass
 class TestClassOelintVarAppendOp(TestBaseClass):
 
     @pytest.mark.parametrize('id', ['oelint.vars.appendop'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -71,11 +71,11 @@ class TestClassOelintVarAppendOp(TestBaseClass):
             },
         ],
     )
-    def test_bad(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_bad(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.vars.appendop'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -136,5 +136,5 @@ class TestClassOelintVarAppendOp(TestBaseClass):
             },
         ],
     )
-    def test_good(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_good(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)

--- a/tests/test_class_oelint_vars_autorev.py
+++ b/tests/test_class_oelint_vars_autorev.py
@@ -10,7 +10,7 @@ from base import TestBaseClass
 class TestClassOelintVarsAutorev(TestBaseClass):
 
     @pytest.mark.parametrize('id', ['oelint.vars.autorev'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -21,11 +21,11 @@ class TestClassOelintVarsAutorev(TestBaseClass):
             },
         ],
     )
-    def test_bad(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_bad(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.vars.autorev'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -42,5 +42,5 @@ class TestClassOelintVarsAutorev(TestBaseClass):
             },
         ],
     )
-    def test_good(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_good(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)

--- a/tests/test_class_oelint_vars_bbvars.py
+++ b/tests/test_class_oelint_vars_bbvars.py
@@ -15,7 +15,7 @@ class TestClassOelintVarsBBVars(TestBaseClass):
             '''.format(var=var, operation=operation)
 
     @pytest.mark.parametrize('id', ['oelint.vars.bbvars'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('var', [
             "BB_CONSOLELOG",
             "BB_CURRENTTASK",
@@ -91,16 +91,16 @@ class TestClassOelintVarsBBVars(TestBaseClass):
             "TOPDIR"
     ])
     @pytest.mark.parametrize('operation', ['=', ':=', '.=', '=.', '+=', '=+'])
-    def test_bad(self, id, occurance, var, operation):
+    def test_bad(self, id, occurrence, var, operation):
         input = {
             'oelint_adv_test.bb': self.__generate_sample_code(var, operation)
         }
         id += '.{}'.format(var)
-        self.check_for_id(self._create_args(input), id, occurance)
+        self.check_for_id(self._create_args(input), id, occurrence)
 
 
     @pytest.mark.parametrize('id', ['oelint.vars.bbvars'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('var', [
             "BB_CONSOLELOG",
             "BB_CURRENTTASK",
@@ -177,9 +177,9 @@ class TestClassOelintVarsBBVars(TestBaseClass):
             "TOPDIR"
     ])
     @pytest.mark.parametrize('operation', ['?=', '??='])
-    def test_good_weak(self, id, occurance, var, operation):
+    def test_good_weak(self, id, occurrence, var, operation):
         input = {
             'oelint_adv_test.bb': self.__generate_sample_code(var, operation)
         }
         id += '.{}'.format(var)
-        self.check_for_id(self._create_args(input), id, occurance)
+        self.check_for_id(self._create_args(input), id, occurrence)

--- a/tests/test_class_oelint_vars_bugtrackerurl.py
+++ b/tests/test_class_oelint_vars_bugtrackerurl.py
@@ -10,7 +10,7 @@ from base import TestBaseClass
 class TestClassOelintVarsBugtrackerIsUrl(TestBaseClass):
 
     @pytest.mark.parametrize('id', ['oelint.vars.bugtrackerisurl'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -27,11 +27,11 @@ class TestClassOelintVarsBugtrackerIsUrl(TestBaseClass):
             },
         ],
     )
-    def test_bad(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_bad(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.vars.bugtrackerisurl'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -42,5 +42,5 @@ class TestClassOelintVarsBugtrackerIsUrl(TestBaseClass):
             },
         ],
     )
-    def test_good(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_good(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)

--- a/tests/test_class_oelint_vars_dependsappend.py
+++ b/tests/test_class_oelint_vars_dependsappend.py
@@ -10,7 +10,7 @@ from base import TestBaseClass
 class TestClassOelintVarsDependsAppend(TestBaseClass):
 
     @pytest.mark.parametrize('id', ['oelint.vars.dependsappend'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -21,11 +21,11 @@ class TestClassOelintVarsDependsAppend(TestBaseClass):
             },
         ],
     )
-    def test_bad(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_bad(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.vars.dependsappend'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -54,5 +54,5 @@ class TestClassOelintVarsDependsAppend(TestBaseClass):
             },
         ],
     )
-    def test_good(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_good(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)

--- a/tests/test_class_oelint_vars_dependsordered.py
+++ b/tests/test_class_oelint_vars_dependsordered.py
@@ -10,7 +10,7 @@ from base import TestBaseClass
 class TestClassOelintVarsDependsOrdered(TestBaseClass):
 
     @pytest.mark.parametrize('id', ['oelint.vars.dependsordered'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -43,11 +43,11 @@ class TestClassOelintVarsDependsOrdered(TestBaseClass):
             },
         ],
     )
-    def test_bad(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_bad(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.vars.dependsordered'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -129,5 +129,5 @@ class TestClassOelintVarsDependsOrdered(TestBaseClass):
             },
         ],
     )
-    def test_good(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_good(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)

--- a/tests/test_class_oelint_vars_descriptionsame.py
+++ b/tests/test_class_oelint_vars_descriptionsame.py
@@ -10,7 +10,7 @@ from base import TestBaseClass
 class TestClassOelintVarsDescriptionSame(TestBaseClass):
 
     @pytest.mark.parametrize('id', ['oelint.vars.descriptionsame'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -22,11 +22,11 @@ class TestClassOelintVarsDescriptionSame(TestBaseClass):
             }
         ],
     )
-    def test_bad(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_bad(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.vars.descriptionsame'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -50,5 +50,5 @@ class TestClassOelintVarsDescriptionSame(TestBaseClass):
             },
         ],
     )
-    def test_good(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_good(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)

--- a/tests/test_class_oelint_vars_descriptiontoobrief.py
+++ b/tests/test_class_oelint_vars_descriptiontoobrief.py
@@ -10,7 +10,7 @@ from base import TestBaseClass
 class TestClassOelintVarsDescriptionTooBrief(TestBaseClass):
 
     @pytest.mark.parametrize('id', ['oelint.vars.descriptiontoobrief'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -22,11 +22,11 @@ class TestClassOelintVarsDescriptionTooBrief(TestBaseClass):
             }
         ],
     )
-    def test_bad(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_bad(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.vars.descriptiontoobrief'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -50,5 +50,5 @@ class TestClassOelintVarsDescriptionTooBrief(TestBaseClass):
             },
         ],
     )
-    def test_good(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_good(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)

--- a/tests/test_class_oelint_vars_doublemodify.py
+++ b/tests/test_class_oelint_vars_doublemodify.py
@@ -10,7 +10,7 @@ from base import TestBaseClass
 class TestClassOelintVarsDoubleModify(TestBaseClass):
 
     @pytest.mark.parametrize('id', ['oelint.vars.doublemodify'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -69,11 +69,11 @@ class TestClassOelintVarsDoubleModify(TestBaseClass):
             },
         ],
     )
-    def test_bad(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_bad(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.vars.doublemodify'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -108,5 +108,5 @@ class TestClassOelintVarsDoubleModify(TestBaseClass):
             },
         ],
     )
-    def test_good(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_good(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)

--- a/tests/test_class_oelint_vars_duplicate.py
+++ b/tests/test_class_oelint_vars_duplicate.py
@@ -10,7 +10,7 @@ from base import TestBaseClass
 class TestClassOelintVarsDuplicate(TestBaseClass):
 
     @pytest.mark.parametrize('id', ['oelint.vars.duplicate'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -36,11 +36,11 @@ class TestClassOelintVarsDuplicate(TestBaseClass):
             }
         ],
     )
-    def test_bad(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_bad(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.vars.duplicate'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -81,5 +81,5 @@ class TestClassOelintVarsDuplicate(TestBaseClass):
 
         ],
     )
-    def test_good(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_good(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)

--- a/tests/test_class_oelint_vars_fileextrapaths.py
+++ b/tests/test_class_oelint_vars_fileextrapaths.py
@@ -10,7 +10,7 @@ from base import TestBaseClass
 class TestClassOelintVarsFilextrapaths(TestBaseClass):
 
     @pytest.mark.parametrize('id', ['oelint.vars.fileextrapaths'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -33,11 +33,11 @@ class TestClassOelintVarsFilextrapaths(TestBaseClass):
             }
         ],
     )
-    def test_bad(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_bad(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.vars.fileextrapaths'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -54,5 +54,5 @@ class TestClassOelintVarsFilextrapaths(TestBaseClass):
             },
         ],
     )
-    def test_good(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_good(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)

--- a/tests/test_class_oelint_vars_fileextrapathsop.py
+++ b/tests/test_class_oelint_vars_fileextrapathsop.py
@@ -10,7 +10,7 @@ from base import TestBaseClass
 class TestClassOelintVarsFilextrapaths(TestBaseClass):
 
     @pytest.mark.parametrize('id', ['oelint.vars.fileextrapathsop'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -52,11 +52,11 @@ class TestClassOelintVarsFilextrapaths(TestBaseClass):
             }
         ],
     )
-    def test_bad(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_bad(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.vars.fileextrapathsop'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -79,5 +79,5 @@ class TestClassOelintVarsFilextrapaths(TestBaseClass):
             },
         ],
     )
-    def test_good(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_good(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)

--- a/tests/test_class_oelint_vars_filessetting_double.py
+++ b/tests/test_class_oelint_vars_filessetting_double.py
@@ -10,7 +10,7 @@ from base import TestBaseClass
 class TestClassOelintVarsFileSettingsDouble(TestBaseClass):
 
     @pytest.mark.parametrize('id', ['oelint.vars.filessetting.double'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -41,11 +41,11 @@ class TestClassOelintVarsFileSettingsDouble(TestBaseClass):
             },
         ],
     )
-    def test_bad(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_bad(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.vars.filessetting.double'])
-    @pytest.mark.parametrize('occurance', [2])
+    @pytest.mark.parametrize('occurrence', [2])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -58,11 +58,11 @@ class TestClassOelintVarsFileSettingsDouble(TestBaseClass):
             }
         ],
     )
-    def test_bad_non_default(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_bad_non_default(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.vars.filessetting.double'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -74,5 +74,5 @@ class TestClassOelintVarsFileSettingsDouble(TestBaseClass):
             }
         ],
     )
-    def test_good(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_good(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)

--- a/tests/test_class_oelint_vars_filessetting_hidden.py
+++ b/tests/test_class_oelint_vars_filessetting_hidden.py
@@ -10,7 +10,7 @@ from base import TestBaseClass
 class TestClassOelintVarsFileSettingsHidden(TestBaseClass):
 
     @pytest.mark.parametrize('id', ['oelint.vars.filessetting.hidden'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -61,11 +61,11 @@ class TestClassOelintVarsFileSettingsHidden(TestBaseClass):
             },
         ],
     )
-    def test_bad(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_bad(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.vars.filessetting.hidden'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -116,5 +116,5 @@ class TestClassOelintVarsFileSettingsHidden(TestBaseClass):
             },
         ],
     )
-    def test_good(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_good(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)

--- a/tests/test_class_oelint_vars_homepageping.py
+++ b/tests/test_class_oelint_vars_homepageping.py
@@ -10,7 +10,7 @@ from base import TestBaseClass
 class TestClassOelintVarsHomepagePing(TestBaseClass):
 
     @pytest.mark.parametrize('id', ['oelint.vars.homepageping'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -21,11 +21,11 @@ class TestClassOelintVarsHomepagePing(TestBaseClass):
             },
         ],
     )
-    def test_bad(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_bad(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.vars.homepageping'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -36,5 +36,5 @@ class TestClassOelintVarsHomepagePing(TestBaseClass):
             },
         ],
     )
-    def test_good(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_good(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)

--- a/tests/test_class_oelint_vars_homepageprefix.py
+++ b/tests/test_class_oelint_vars_homepageprefix.py
@@ -10,13 +10,13 @@ from base import TestBaseClass
 class TestClassOelintVarsHomepagePrefix(TestBaseClass):
 
     @pytest.mark.parametrize('id', ['oelint.vars.homepageprefix'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('input', 
         [
             {
             'oelint_adv_test.bb':
             '''
-            HOMEPAGE = "ftp://isnt/21stcentury/tech"
+            HOMEPAGE = "ftp://isn't/21stcentury/tech"
             '''
             },
             {
@@ -28,16 +28,16 @@ class TestClassOelintVarsHomepagePrefix(TestBaseClass):
             {
             'oelint_adv_test.bb':
             '''
-            HOMEPAGE = "ssh://wont/get/u/anywhere"
+            HOMEPAGE = "ssh://won't/get/u/anywhere"
             '''
             },
         ],
     )
-    def test_bad(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_bad(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.vars.homepageprefix'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -60,5 +60,5 @@ class TestClassOelintVarsHomepagePrefix(TestBaseClass):
             },
         ],
     )
-    def test_good(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_good(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)

--- a/tests/test_class_oelint_vars_inconspaces.py
+++ b/tests/test_class_oelint_vars_inconspaces.py
@@ -10,7 +10,7 @@ from base import TestBaseClass
 class TestClassOelintVarsInconSpaces(TestBaseClass):
 
     @pytest.mark.parametrize('id', ['oelint.vars.inconspaces'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -35,11 +35,11 @@ class TestClassOelintVarsInconSpaces(TestBaseClass):
             },
         ],
     )
-    def test_bad(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_bad(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.vars.inconspaces'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -78,5 +78,5 @@ class TestClassOelintVarsInconSpaces(TestBaseClass):
             },
         ],
     )
-    def test_good(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_good(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)

--- a/tests/test_class_oelint_vars_insaneskip.py
+++ b/tests/test_class_oelint_vars_insaneskip.py
@@ -10,7 +10,7 @@ from base import TestBaseClass
 class TestClassOelintVarsInsaneSkip(TestBaseClass):
 
     @pytest.mark.parametrize('id', ['oelint.vars.insaneskip'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -33,11 +33,11 @@ class TestClassOelintVarsInsaneSkip(TestBaseClass):
             },
         ],
     )
-    def test_bad(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_bad(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.vars.insaneskip'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -48,5 +48,5 @@ class TestClassOelintVarsInsaneSkip(TestBaseClass):
             },
         ],
     )
-    def test_good(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_good(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)

--- a/tests/test_class_oelint_vars_licensefileprefix.py
+++ b/tests/test_class_oelint_vars_licensefileprefix.py
@@ -10,7 +10,7 @@ from base import TestBaseClass
 class TestClassOelintVarsLicenseFilePrefix(TestBaseClass):
 
     @pytest.mark.parametrize('id', ['oelint.vars.licfileprefix'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -21,11 +21,11 @@ class TestClassOelintVarsLicenseFilePrefix(TestBaseClass):
             },
         ],
     )
-    def test_bad(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_bad(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.vars.licfileprefix'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -42,5 +42,5 @@ class TestClassOelintVarsLicenseFilePrefix(TestBaseClass):
             },
         ],
     )
-    def test_good(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_good(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)

--- a/tests/test_class_oelint_vars_listappend.py
+++ b/tests/test_class_oelint_vars_listappend.py
@@ -10,7 +10,7 @@ from base import TestBaseClass
 class TestClassOelintVarsListAppend(TestBaseClass):
 
     @pytest.mark.parametrize('id', ['oelint.vars.listappend'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -45,11 +45,11 @@ class TestClassOelintVarsListAppend(TestBaseClass):
             },
         ],
     )
-    def test_bad(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_bad(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.vars.listappend'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -84,5 +84,5 @@ class TestClassOelintVarsListAppend(TestBaseClass):
             },
         ],
     )
-    def test_good(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_good(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)

--- a/tests/test_class_oelint_vars_misspell.py
+++ b/tests/test_class_oelint_vars_misspell.py
@@ -10,7 +10,7 @@ from base import TestBaseClass
 class TestClassOelintVarsMispell(TestBaseClass):
 
     @pytest.mark.parametrize('id', ['oelint.vars.mispell'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -27,11 +27,11 @@ class TestClassOelintVarsMispell(TestBaseClass):
             },
         ],
     )
-    def test_bad(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_bad(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.vars.mispell'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -76,5 +76,5 @@ class TestClassOelintVarsMispell(TestBaseClass):
             },
         ],
     )
-    def test_good(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_good(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)

--- a/tests/test_class_oelint_vars_multilineident.py
+++ b/tests/test_class_oelint_vars_multilineident.py
@@ -10,7 +10,7 @@ from base import TestBaseClass
 class TestClassOelintVarsMultilineIdent(TestBaseClass):
 
     @pytest.mark.parametrize('id', ['oelint.vars.multilineident'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -24,11 +24,11 @@ class TestClassOelintVarsMultilineIdent(TestBaseClass):
             },
         ],
     )
-    def test_bad(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_bad(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)
     
     @pytest.mark.parametrize('id', ['oelint.vars.multilineident'])
-    @pytest.mark.parametrize('occurance', [2])
+    @pytest.mark.parametrize('occurrence', [2])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -58,11 +58,11 @@ class TestClassOelintVarsMultilineIdent(TestBaseClass):
             },
         ],
     )
-    def test_bad_two(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_bad_two(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.vars.multilineident'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -94,5 +94,5 @@ class TestClassOelintVarsMultilineIdent(TestBaseClass):
             },
         ],
     )
-    def test_good(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_good(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)

--- a/tests/test_class_oelint_vars_notneededspace.py
+++ b/tests/test_class_oelint_vars_notneededspace.py
@@ -10,7 +10,7 @@ from base import TestBaseClass
 class TestClassOelintVarsNotNeededSpace(TestBaseClass):
 
     @pytest.mark.parametrize('id', ['oelint.vars.notneededspace'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -27,8 +27,8 @@ class TestClassOelintVarsNotNeededSpace(TestBaseClass):
             },
         ],
     )
-    def test_bad(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_bad(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.vars.notneededspace'])
     @pytest.mark.parametrize('input', 
@@ -51,7 +51,7 @@ class TestClassOelintVarsNotNeededSpace(TestBaseClass):
         self.fix_and_check(self._create_args_fix(input), id)
 
     @pytest.mark.parametrize('id', ['oelint.vars.notneededspace'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -74,5 +74,5 @@ class TestClassOelintVarsNotNeededSpace(TestBaseClass):
             },
         ],
     )
-    def test_good(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_good(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)

--- a/tests/test_class_oelint_vars_notrailingslash.py
+++ b/tests/test_class_oelint_vars_notrailingslash.py
@@ -10,7 +10,7 @@ from base import TestBaseClass
 class TestClassOelintVarsNoTrailingSlash(TestBaseClass):
 
     @pytest.mark.parametrize('id', ['oelint.vars.notrailingslash'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -46,11 +46,11 @@ class TestClassOelintVarsNoTrailingSlash(TestBaseClass):
             },
         ],
     )
-    def test_bad(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_bad(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.vars.notrailingslash'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('input', 
         [
                         {
@@ -92,5 +92,5 @@ class TestClassOelintVarsNoTrailingSlash(TestBaseClass):
             },
         ],
     )
-    def test_good(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_good(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)

--- a/tests/test_class_oelint_vars_pathhardcode.py
+++ b/tests/test_class_oelint_vars_pathhardcode.py
@@ -15,7 +15,7 @@ class TestClassOelintVarsPathHardcode(TestBaseClass):
             '''.format(var=var)
 
     @pytest.mark.parametrize('id', ['oelint.vars.pathhardcode'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('pair', [
         ( "${systemd_user_unitdir}", "/usr/lib/systemd/user" ),
         ( "${systemd_system_unitdir}", "/lib/systemd/system" ),
@@ -35,7 +35,7 @@ class TestClassOelintVarsPathHardcode(TestBaseClass):
         ( "${sharedstatedir}", "/com" ),
         ( "${sysconfdir}", "/etc" ),
     ])
-    def test_bad(self, id, occurance, pair):
+    def test_bad(self, id, occurrence, pair):
         id += '.{}'.format(pair[0].strip('${}'))
         for variation in [pair[1], 
                           pair[1] + "/", 
@@ -45,10 +45,10 @@ class TestClassOelintVarsPathHardcode(TestBaseClass):
             input = {
                 'oelint_adv_test.bb': self.__generate_sample_code(variation)
             }
-            self.check_for_id(self._create_args(input), id, occurance)
+            self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.vars.pathhardcode'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('pair', [
         ( "${systemd_user_unitdir}", "/usr/lib/systemd/user" ),
         ( "${systemd_system_unitdir}", "/lib/systemd/system" ),
@@ -70,7 +70,7 @@ class TestClassOelintVarsPathHardcode(TestBaseClass):
         ( "${sharedstatedir}", "/com" ),
         ( "${sysconfdir}", "/etc" ),
     ])
-    def test_good(self, id, occurance, pair):
+    def test_good(self, id, occurrence, pair):
         id += '.{}'.format(pair[0].strip('${}'))
         for variation in [pair[0],
                           pair[0] + "/", 
@@ -80,10 +80,10 @@ class TestClassOelintVarsPathHardcode(TestBaseClass):
             input = {
                 'oelint_adv_test.bb': self.__generate_sample_code(variation)
             }
-            self.check_for_id(self._create_args(input), id, occurance)
+            self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.vars.pathhardcode'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -112,5 +112,5 @@ class TestClassOelintVarsPathHardcode(TestBaseClass):
             },
         ],
     )
-    def test_good_pattern(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_good_pattern(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)

--- a/tests/test_class_oelint_vars_pbpusage.py
+++ b/tests/test_class_oelint_vars_pbpusage.py
@@ -10,7 +10,7 @@ from base import TestBaseClass
 class TestClassOelintVarsPBPUsage(TestBaseClass):
 
     @pytest.mark.parametrize('id', ['oelint.vars.pbpusage'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -39,11 +39,11 @@ class TestClassOelintVarsPBPUsage(TestBaseClass):
             },
         ],
     )
-    def test_bad(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_bad(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.vars.pbpusage'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -78,5 +78,5 @@ class TestClassOelintVarsPBPUsage(TestBaseClass):
             },
         ],
     )
-    def test_good(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_good(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)

--- a/tests/test_class_oelint_vars_pkgspecific.py
+++ b/tests/test_class_oelint_vars_pkgspecific.py
@@ -15,7 +15,7 @@ class TestClassOelintVarsPKGSpecific(TestBaseClass):
             '''.format(var=var)
 
     @pytest.mark.parametrize('id', ['oelint.vars.pkgspecific'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('var', [
         "RDEPENDS",
         "RRECOMMENDS",
@@ -30,15 +30,15 @@ class TestClassOelintVarsPKGSpecific(TestBaseClass):
         "pkg_postrm",
         "ALLOW_EMPTY",
     ])
-    def test_bad(self, id, occurance, var):
+    def test_bad(self, id, occurrence, var):
         input = {
             'oelint_adv_test.bb': self.__generate_sample_code(var)
         }
         id += '.{}'.format(var)
-        self.check_for_id(self._create_args(input), id, occurance)
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.vars.pkgspecific'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('var', [
         "RDEPENDS",
         "RRECOMMENDS",
@@ -53,16 +53,16 @@ class TestClassOelintVarsPKGSpecific(TestBaseClass):
         "pkg_postrm",
         "ALLOW_EMPTY",
     ])
-    def test_bad_append_with_bb(self, id, occurance, var):
+    def test_bad_append_with_bb(self, id, occurrence, var):
         input = {
             'oelint-adv-test_1.0.bb': 'VAR = "FOO"',
             'oelint-adv-test_1.0.bbappend': self.__generate_sample_code(var),
         }
         id += '.{}'.format(var)
-        self.check_for_id(self._create_args(input), id, occurance)
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.vars.pkgspecific'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('var', [
         "RDEPENDS_${PN}",
         "RRECOMMENDS_${PN}",
@@ -77,15 +77,15 @@ class TestClassOelintVarsPKGSpecific(TestBaseClass):
         "pkg_postrm_${PN}",
         "ALLOW_EMPTY_${PN}",
     ])
-    def test_good(self, id, occurance, var):
+    def test_good(self, id, occurrence, var):
         input = {
             'oelint_adv_test.bb': self.__generate_sample_code(var)
         }
         id += '.{}'.format(var)
-        self.check_for_id(self._create_args(input), id, occurance)
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.vars.pkgspecific'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('var', [
         "RDEPENDS_foo",
         "RRECOMMENDS_foo",
@@ -100,12 +100,12 @@ class TestClassOelintVarsPKGSpecific(TestBaseClass):
         "pkg_postrm_foo",
         "ALLOW_EMPTY_foo",
     ])
-    def test_good_bbappend(self, id, occurance, var):
+    def test_good_bbappend(self, id, occurrence, var):
         input = {
             'oelint_adv_test_%.bbappend': self.__generate_sample_code(var)
         }
         id += '.{}'.format(var)
-        self.check_for_id(self._create_args(input), id, occurance)
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', [
         'oelint.var.pkgspecific.RDEPENDS',
@@ -121,7 +121,7 @@ class TestClassOelintVarsPKGSpecific(TestBaseClass):
         'oelint.var.pkgspecific.pkg_postrm',
         'oelint.var.pkgspecific.ALLOW_EMPTY',
         ])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -133,8 +133,8 @@ class TestClassOelintVarsPKGSpecific(TestBaseClass):
             },
         ],
     )
-    def test_good_custom_pkg(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_good_custom_pkg(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)
 
 
  

--- a/tests/test_class_oelint_vars_pnbpnusage.py
+++ b/tests/test_class_oelint_vars_pnbpnusage.py
@@ -10,7 +10,7 @@ from base import TestBaseClass
 class TestClassOelintVarsPNBPNUsage(TestBaseClass):
 
     @pytest.mark.parametrize('id', ['oelint.vars.pnbpnusage'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -33,11 +33,11 @@ class TestClassOelintVarsPNBPNUsage(TestBaseClass):
             },
         ],
     )
-    def test_bad(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_bad(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.vars.pnbpnusage'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -78,5 +78,5 @@ class TestClassOelintVarsPNBPNUsage(TestBaseClass):
             },
         ],
     )
-    def test_good(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_good(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)

--- a/tests/test_class_oelint_vars_pnusagedis.py
+++ b/tests/test_class_oelint_vars_pnusagedis.py
@@ -10,7 +10,7 @@ from base import TestBaseClass
 class TestClassOelintVarsPNUsageDiscouraged(TestBaseClass):
 
     @pytest.mark.parametrize('id', ['oelint.vars.pnusagediscouraged'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -39,11 +39,11 @@ class TestClassOelintVarsPNUsageDiscouraged(TestBaseClass):
             },
         ],
     )
-    def test_bad(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_bad(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.vars.pnusagediscouraged'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -72,5 +72,5 @@ class TestClassOelintVarsPNUsageDiscouraged(TestBaseClass):
             },
         ],
     )
-    def test_good(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_good(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)

--- a/tests/test_class_oelint_vars_sectionlowercase.py
+++ b/tests/test_class_oelint_vars_sectionlowercase.py
@@ -10,7 +10,7 @@ from base import TestBaseClass
 class TestClassOelintVarsSectionLowerCase(TestBaseClass):
 
     @pytest.mark.parametrize('id', ['oelint.vars.sectionlowercase'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -21,8 +21,8 @@ class TestClassOelintVarsSectionLowerCase(TestBaseClass):
             },
         ],
     )
-    def test_bad(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_bad(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.vars.sectionlowercase'])
     @pytest.mark.parametrize('input', 
@@ -39,7 +39,7 @@ class TestClassOelintVarsSectionLowerCase(TestBaseClass):
         self.fix_and_check(self._create_args_fix(input), id)
 
     @pytest.mark.parametrize('id', ['oelint.vars.sectionlowercase'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -50,5 +50,5 @@ class TestClassOelintVarsSectionLowerCase(TestBaseClass):
             },
         ],
     )
-    def test_good(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_good(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)

--- a/tests/test_class_oelint_vars_spaceassignment.py
+++ b/tests/test_class_oelint_vars_spaceassignment.py
@@ -15,7 +15,7 @@ class TestClassOelintVarsSectionLowerCase(TestBaseClass):
             '''.format(op=op)
 
     @pytest.mark.parametrize('id', ['oelint.vars.spacesassignment'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('op', 
         [
             " :=",
@@ -44,14 +44,14 @@ class TestClassOelintVarsSectionLowerCase(TestBaseClass):
             "=+",
         ],
     )
-    def test_bad(self, op, id, occurance):
+    def test_bad(self, op, id, occurrence):
         input = {
             'oelint_adv_test.bb': self.__generate_sample_code(op)
         }
-        self.check_for_id(self._create_args(input), id, occurance)
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.vars.spacesassignment'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('op', 
         [
             " = ",
@@ -64,8 +64,8 @@ class TestClassOelintVarsSectionLowerCase(TestBaseClass):
             " := ",
         ],
     )
-    def test_good(self, op, id, occurance):
+    def test_good(self, op, id, occurrence):
         input = {
             'oelint_adv_test.bb': self.__generate_sample_code(op)
         }
-        self.check_for_id(self._create_args(input), id, occurance)
+        self.check_for_id(self._create_args(input), id, occurrence)

--- a/tests/test_class_oelint_vars_specific.py
+++ b/tests/test_class_oelint_vars_specific.py
@@ -10,7 +10,7 @@ from base import TestBaseClass
 class TestClassOelintVarsSpecific(TestBaseClass):
 
     @pytest.mark.parametrize('id', ['oelint.vars.specific'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -41,11 +41,11 @@ class TestClassOelintVarsSpecific(TestBaseClass):
             },
         ],
     )
-    def test_bad(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_bad(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.vars.specific'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -126,5 +126,5 @@ class TestClassOelintVarsSpecific(TestBaseClass):
             },
         ],
     )
-    def test_good(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_good(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)

--- a/tests/test_class_oelint_vars_srcuriappend.py
+++ b/tests/test_class_oelint_vars_srcuriappend.py
@@ -10,7 +10,7 @@ from base import TestBaseClass
 class TestClassOelintVarsSRCURIappend(TestBaseClass):
 
     @pytest.mark.parametrize('id', ['oelint.vars.srcuriappend'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -22,11 +22,11 @@ class TestClassOelintVarsSRCURIappend(TestBaseClass):
             },
         ],
     )
-    def test_bad(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_bad(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.vars.srcuriappend'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -75,5 +75,5 @@ class TestClassOelintVarsSRCURIappend(TestBaseClass):
             }
         ],
     )
-    def test_good(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_good(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)

--- a/tests/test_class_oelint_vars_srcuridomains.py
+++ b/tests/test_class_oelint_vars_srcuridomains.py
@@ -10,7 +10,7 @@ from base import TestBaseClass
 class TestClassOelintVarsSRCURIdomains(TestBaseClass):
 
     @pytest.mark.parametrize('id', ['oelint.vars.srcuridomains'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -22,11 +22,11 @@ class TestClassOelintVarsSRCURIdomains(TestBaseClass):
             },
         ],
     )
-    def test_bad(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_bad(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.vars.srcuridomains'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -45,5 +45,5 @@ class TestClassOelintVarsSRCURIdomains(TestBaseClass):
             },
         ],
     )
-    def test_good(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_good(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)

--- a/tests/test_class_oelint_vars_srcurifile.py
+++ b/tests/test_class_oelint_vars_srcurifile.py
@@ -10,7 +10,7 @@ from base import TestBaseClass
 class TestClassOelintVarsSRCURIfile(TestBaseClass):
 
     @pytest.mark.parametrize('id', ['oelint.vars.srcurifile'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -37,11 +37,11 @@ class TestClassOelintVarsSRCURIfile(TestBaseClass):
             },
         ],
     )
-    def test_bad(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_bad(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.vars.srcurifile'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -92,5 +92,5 @@ class TestClassOelintVarsSRCURIfile(TestBaseClass):
             },
         ],
     )
-    def test_good(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_good(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)

--- a/tests/test_class_oelint_vars_srcurigittag.py
+++ b/tests/test_class_oelint_vars_srcurigittag.py
@@ -10,7 +10,7 @@ from base import TestBaseClass
 class TestClassOelintVarsSRCURIGitTag(TestBaseClass):
 
     @pytest.mark.parametrize('id', ['oelint.vars.srcurigittag'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -27,11 +27,11 @@ class TestClassOelintVarsSRCURIGitTag(TestBaseClass):
             }
         ],
     )
-    def test_bad(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_bad(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.vars.srcurigittag'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -78,5 +78,5 @@ class TestClassOelintVarsSRCURIGitTag(TestBaseClass):
             },
         ],
     )
-    def test_good(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_good(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)

--- a/tests/test_class_oelint_vars_srcurioptions.py
+++ b/tests/test_class_oelint_vars_srcurioptions.py
@@ -312,427 +312,427 @@ class TestClassOelintVarsSRCURIOptions(TestBaseClass):
             '''.format(protocol=protocol, option=option)
 
     @pytest.mark.parametrize('id', ['oelint.vars.srcurioptions'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('protocol', ['az'])
     @pytest.mark.parametrize('option', [x for x in OPTIONS_AVAILABLE if x not in OPTION_MAPPING['az']])
-    def test_bad_az(self, id, occurance, protocol, option):
+    def test_bad_az(self, id, occurrence, protocol, option):
         input = {
             'oelint_adv_test.bb': self.__generate_sample_code(protocol, option)
         }
-        self.check_for_id(self._create_args(input), id, occurance)
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.vars.srcurioptions'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('protocol', ['az'])
     @pytest.mark.parametrize('option', OPTION_MAPPING['az'])
-    def test_good_az(self, id, occurance, protocol, option):
+    def test_good_az(self, id, occurrence, protocol, option):
         input = {
             'oelint_adv_test.bb': self.__generate_sample_code(protocol, option)
         }
-        self.check_for_id(self._create_args(input), id, occurance)
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.vars.srcurioptions'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('protocol', ['bzr'])
     @pytest.mark.parametrize('option', [x for x in OPTIONS_AVAILABLE if x not in OPTION_MAPPING['bzr']])
-    def test_bad_bzr(self, id, occurance, protocol, option):
+    def test_bad_bzr(self, id, occurrence, protocol, option):
         input = {
             'oelint_adv_test.bb': self.__generate_sample_code(protocol, option)
         }
-        self.check_for_id(self._create_args(input), id, occurance)
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.vars.srcurioptions'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('protocol', ['bzr'])
     @pytest.mark.parametrize('option', OPTION_MAPPING['bzr'])
-    def test_good_bzr(self, id, occurance, protocol, option):
+    def test_good_bzr(self, id, occurrence, protocol, option):
         input = {
             'oelint_adv_test.bb': self.__generate_sample_code(protocol, option)
         }
-        self.check_for_id(self._create_args(input), id, occurance)
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.vars.srcurioptions'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('protocol', ['crcc'])
     @pytest.mark.parametrize('option', [x for x in OPTIONS_AVAILABLE if x not in OPTION_MAPPING['crcc']])
-    def test_bad_crcc(self, id, occurance, protocol, option):
+    def test_bad_crcc(self, id, occurrence, protocol, option):
         input = {
             'oelint_adv_test.bb': self.__generate_sample_code(protocol, option)
         }
-        self.check_for_id(self._create_args(input), id, occurance)
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.vars.srcurioptions'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('protocol', ['crcc'])
     @pytest.mark.parametrize('option', OPTION_MAPPING['crcc'])
-    def test_good_crcc(self, id, occurance, protocol, option):
+    def test_good_crcc(self, id, occurrence, protocol, option):
         input = {
             'oelint_adv_test.bb': self.__generate_sample_code(protocol, option)
         }
-        self.check_for_id(self._create_args(input), id, occurance)
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.vars.srcurioptions'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('protocol', ['cvs'])
     @pytest.mark.parametrize('option', [x for x in OPTIONS_AVAILABLE if x not in OPTION_MAPPING['cvs']])
-    def test_bad_cvs(self, id, occurance, protocol, option):
+    def test_bad_cvs(self, id, occurrence, protocol, option):
         input = {
             'oelint_adv_test.bb': self.__generate_sample_code(protocol, option)
         }
-        self.check_for_id(self._create_args(input), id, occurance)
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.vars.srcurioptions'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('protocol', ['cvs'])
     @pytest.mark.parametrize('option', OPTION_MAPPING['cvs'])
-    def test_good_cvs(self, id, occurance, protocol, option):
+    def test_good_cvs(self, id, occurrence, protocol, option):
         input = {
             'oelint_adv_test.bb': self.__generate_sample_code(protocol, option)
         }
-        self.check_for_id(self._create_args(input), id, occurance)
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.vars.srcurioptions'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('protocol', ['file'])
     @pytest.mark.parametrize('option', [x for x in OPTIONS_AVAILABLE if x not in OPTION_MAPPING['file']])
-    def test_bad_file(self, id, occurance, protocol, option):
+    def test_bad_file(self, id, occurrence, protocol, option):
         input = {
             'oelint_adv_test.bb': self.__generate_sample_code(protocol, option)
         }
-        self.check_for_id(self._create_args(input), id, occurance)
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.vars.srcurioptions'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('protocol', ['file'])
     @pytest.mark.parametrize('option', OPTION_MAPPING['file'])
-    def test_good_file(self, id, occurance, protocol, option):
+    def test_good_file(self, id, occurrence, protocol, option):
         input = {
             'oelint_adv_test.bb': self.__generate_sample_code(protocol, option)
         }
-        self.check_for_id(self._create_args(input), id, occurance)
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.vars.srcurioptions'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('protocol', ['ftp'])
     @pytest.mark.parametrize('option', [x for x in OPTIONS_AVAILABLE if x not in OPTION_MAPPING['ftp']])
-    def test_bad_ftp(self, id, occurance, protocol, option):
+    def test_bad_ftp(self, id, occurrence, protocol, option):
         input = {
             'oelint_adv_test.bb': self.__generate_sample_code(protocol, option)
         }
-        self.check_for_id(self._create_args(input), id, occurance)
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.vars.srcurioptions'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('protocol', ['ftp'])
     @pytest.mark.parametrize('option', OPTION_MAPPING['ftp'])
-    def test_good_ftp(self, id, occurance, protocol, option):
+    def test_good_ftp(self, id, occurrence, protocol, option):
         input = {
             'oelint_adv_test.bb': self.__generate_sample_code(protocol, option)
         }
-        self.check_for_id(self._create_args(input), id, occurance)
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.vars.srcurioptions'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('protocol', ['git'])
     @pytest.mark.parametrize('option', [x for x in OPTIONS_AVAILABLE if x not in OPTION_MAPPING['git']])
-    def test_bad_git(self, id, occurance, protocol, option):
+    def test_bad_git(self, id, occurrence, protocol, option):
         input = {
             'oelint_adv_test.bb': self.__generate_sample_code(protocol, option)
         }
-        self.check_for_id(self._create_args(input), id, occurance)
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.vars.srcurioptions'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('protocol', ['git'])
     @pytest.mark.parametrize('option', OPTION_MAPPING['git'])
-    def test_good_git(self, id, occurance, protocol, option):
+    def test_good_git(self, id, occurrence, protocol, option):
         input = {
             'oelint_adv_test.bb': self.__generate_sample_code(protocol, option)
         }
-        self.check_for_id(self._create_args(input), id, occurance)
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.vars.srcurioptions'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('protocol', ['gitsm'])
     @pytest.mark.parametrize('option', [x for x in OPTIONS_AVAILABLE if x not in OPTION_MAPPING['gitsm']])
-    def test_bad_gitsm(self, id, occurance, protocol, option):
+    def test_bad_gitsm(self, id, occurrence, protocol, option):
         input = {
             'oelint_adv_test.bb': self.__generate_sample_code(protocol, option)
         }
-        self.check_for_id(self._create_args(input), id, occurance)
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.vars.srcurioptions'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('protocol', ['gitsm'])
     @pytest.mark.parametrize('option', OPTION_MAPPING['gitsm'])
-    def test_good_gitsm(self, id, occurance, protocol, option):
+    def test_good_gitsm(self, id, occurrence, protocol, option):
         input = {
             'oelint_adv_test.bb': self.__generate_sample_code(protocol, option)
         }
-        self.check_for_id(self._create_args(input), id, occurance)
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.vars.srcurioptions'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('protocol', ['gitannex'])
     @pytest.mark.parametrize('option', [x for x in OPTIONS_AVAILABLE if x not in OPTION_MAPPING['gitannex']])
-    def test_bad_gitannex(self, id, occurance, protocol, option):
+    def test_bad_gitannex(self, id, occurrence, protocol, option):
         input = {
             'oelint_adv_test.bb': self.__generate_sample_code(protocol, option)
         }
-        self.check_for_id(self._create_args(input), id, occurance)
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.vars.srcurioptions'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('protocol', ['gitannex'])
     @pytest.mark.parametrize('option', OPTION_MAPPING['gitannex'])
-    def test_good_gitannex(self, id, occurance, protocol, option):
+    def test_good_gitannex(self, id, occurrence, protocol, option):
         input = {
             'oelint_adv_test.bb': self.__generate_sample_code(protocol, option)
         }
-        self.check_for_id(self._create_args(input), id, occurance)
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.vars.srcurioptions'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('protocol', ['hg'])
     @pytest.mark.parametrize('option', [x for x in OPTIONS_AVAILABLE if x not in OPTION_MAPPING['hg']])
-    def test_bad_hg(self, id, occurance, protocol, option):
+    def test_bad_hg(self, id, occurrence, protocol, option):
         input = {
             'oelint_adv_test.bb': self.__generate_sample_code(protocol, option)
         }
-        self.check_for_id(self._create_args(input), id, occurance)
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.vars.srcurioptions'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('protocol', ['hg'])
     @pytest.mark.parametrize('option', OPTION_MAPPING['hg'])
-    def test_good_hg(self, id, occurance, protocol, option):
+    def test_good_hg(self, id, occurrence, protocol, option):
         input = {
             'oelint_adv_test.bb': self.__generate_sample_code(protocol, option)
         }
-        self.check_for_id(self._create_args(input), id, occurance)
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.vars.srcurioptions'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('protocol', ['http'])
     @pytest.mark.parametrize('option', [x for x in OPTIONS_AVAILABLE if x not in OPTION_MAPPING['http']])
-    def test_bad_http(self, id, occurance, protocol, option):
+    def test_bad_http(self, id, occurrence, protocol, option):
         input = {
             'oelint_adv_test.bb': self.__generate_sample_code(protocol, option)
         }
-        self.check_for_id(self._create_args(input), id, occurance)
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.vars.srcurioptions'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('protocol', ['http'])
     @pytest.mark.parametrize('option', OPTION_MAPPING['http'])
-    def test_good_http(self, id, occurance, protocol, option):
+    def test_good_http(self, id, occurrence, protocol, option):
         input = {
             'oelint_adv_test.bb': self.__generate_sample_code(protocol, option)
         }
-        self.check_for_id(self._create_args(input), id, occurance)
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.vars.srcurioptions'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('protocol', ['https'])
     @pytest.mark.parametrize('option', [x for x in OPTIONS_AVAILABLE if x not in OPTION_MAPPING['https']])
-    def test_bad_https(self, id, occurance, protocol, option):
+    def test_bad_https(self, id, occurrence, protocol, option):
         input = {
             'oelint_adv_test.bb': self.__generate_sample_code(protocol, option)
         }
-        self.check_for_id(self._create_args(input), id, occurance)
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.vars.srcurioptions'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('protocol', ['https'])
     @pytest.mark.parametrize('option', OPTION_MAPPING['https'])
-    def test_good_https(self, id, occurance, protocol, option):
+    def test_good_https(self, id, occurrence, protocol, option):
         input = {
             'oelint_adv_test.bb': self.__generate_sample_code(protocol, option)
         }
-        self.check_for_id(self._create_args(input), id, occurance)
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.vars.srcurioptions'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('protocol', ['osc'])
     @pytest.mark.parametrize('option', [x for x in OPTIONS_AVAILABLE if x not in OPTION_MAPPING['osc']])
-    def test_bad_osc(self, id, occurance, protocol, option):
+    def test_bad_osc(self, id, occurrence, protocol, option):
         input = {
             'oelint_adv_test.bb': self.__generate_sample_code(protocol, option)
         }
-        self.check_for_id(self._create_args(input), id, occurance)
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.vars.srcurioptions'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('protocol', ['osc'])
     @pytest.mark.parametrize('option', OPTION_MAPPING['osc'])
-    def test_good_osc(self, id, occurance, protocol, option):
+    def test_good_osc(self, id, occurrence, protocol, option):
         input = {
             'oelint_adv_test.bb': self.__generate_sample_code(protocol, option)
         }
-        self.check_for_id(self._create_args(input), id, occurance)
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.vars.srcurioptions'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('protocol', ['p4'])
     @pytest.mark.parametrize('option', [x for x in OPTIONS_AVAILABLE if x not in OPTION_MAPPING['p4']])
-    def test_bad_p4(self, id, occurance, protocol, option):
+    def test_bad_p4(self, id, occurrence, protocol, option):
         input = {
             'oelint_adv_test.bb': self.__generate_sample_code(protocol, option)
         }
-        self.check_for_id(self._create_args(input), id, occurance)
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.vars.srcurioptions'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('protocol', ['p4'])
     @pytest.mark.parametrize('option', OPTION_MAPPING['p4'])
-    def test_good_p4(self, id, occurance, protocol, option):
+    def test_good_p4(self, id, occurrence, protocol, option):
         input = {
             'oelint_adv_test.bb': self.__generate_sample_code(protocol, option)
         }
-        self.check_for_id(self._create_args(input), id, occurance)
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.vars.srcurioptions'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('protocol', ['repo'])
     @pytest.mark.parametrize('option', [x for x in OPTIONS_AVAILABLE if x not in OPTION_MAPPING['repo']])
-    def test_bad_repo(self, id, occurance, protocol, option):
+    def test_bad_repo(self, id, occurrence, protocol, option):
         input = {
             'oelint_adv_test.bb': self.__generate_sample_code(protocol, option)
         }
-        self.check_for_id(self._create_args(input), id, occurance)
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.vars.srcurioptions'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('protocol', ['repo'])
     @pytest.mark.parametrize('option', OPTION_MAPPING['repo'])
-    def test_good_repo(self, id, occurance, protocol, option):
+    def test_good_repo(self, id, occurrence, protocol, option):
         input = {
             'oelint_adv_test.bb': self.__generate_sample_code(protocol, option)
         }
-        self.check_for_id(self._create_args(input), id, occurance)
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.vars.srcurioptions'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('protocol', ['ssh'])
     @pytest.mark.parametrize('option', [x for x in OPTIONS_AVAILABLE if x not in OPTION_MAPPING['ssh']])
-    def test_bad_ssh(self, id, occurance, protocol, option):
+    def test_bad_ssh(self, id, occurrence, protocol, option):
         input = {
             'oelint_adv_test.bb': self.__generate_sample_code(protocol, option)
         }
-        self.check_for_id(self._create_args(input), id, occurance)
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.vars.srcurioptions'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('protocol', ['ssh'])
     @pytest.mark.parametrize('option', OPTION_MAPPING['ssh'])
-    def test_good_ssh(self, id, occurance, protocol, option):
+    def test_good_ssh(self, id, occurrence, protocol, option):
         input = {
             'oelint_adv_test.bb': self.__generate_sample_code(protocol, option)
         }
-        self.check_for_id(self._create_args(input), id, occurance)
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.vars.srcurioptions'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('protocol', ['s3'])
     @pytest.mark.parametrize('option', [x for x in OPTIONS_AVAILABLE if x not in OPTION_MAPPING['s3']])
-    def test_bad_s3(self, id, occurance, protocol, option):
+    def test_bad_s3(self, id, occurrence, protocol, option):
         input = {
             'oelint_adv_test.bb': self.__generate_sample_code(protocol, option)
         }
-        self.check_for_id(self._create_args(input), id, occurance)
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.vars.srcurioptions'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('protocol', ['s3'])
     @pytest.mark.parametrize('option', OPTION_MAPPING['s3'])
-    def test_good_s3(self, id, occurance, protocol, option):
+    def test_good_s3(self, id, occurrence, protocol, option):
         input = {
             'oelint_adv_test.bb': self.__generate_sample_code(protocol, option)
         }
-        self.check_for_id(self._create_args(input), id, occurance)
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.vars.srcurioptions'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('protocol', ['sftp'])
     @pytest.mark.parametrize('option', [x for x in OPTIONS_AVAILABLE if x not in OPTION_MAPPING['sftp']])
-    def test_bad_sftp(self, id, occurance, protocol, option):
+    def test_bad_sftp(self, id, occurrence, protocol, option):
         input = {
             'oelint_adv_test.bb': self.__generate_sample_code(protocol, option)
         }
-        self.check_for_id(self._create_args(input), id, occurance)
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.vars.srcurioptions'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('protocol', ['sftp'])
     @pytest.mark.parametrize('option', OPTION_MAPPING['sftp'])
-    def test_good_sftp(self, id, occurance, protocol, option):
+    def test_good_sftp(self, id, occurrence, protocol, option):
         input = {
             'oelint_adv_test.bb': self.__generate_sample_code(protocol, option)
         }
-        self.check_for_id(self._create_args(input), id, occurance)
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.vars.srcurioptions'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('protocol', ['npm'])
     @pytest.mark.parametrize('option', [x for x in OPTIONS_AVAILABLE if x not in OPTION_MAPPING['npm']])
-    def test_bad_npm(self, id, occurance, protocol, option):
+    def test_bad_npm(self, id, occurrence, protocol, option):
         input = {
             'oelint_adv_test.bb': self.__generate_sample_code(protocol, option)
         }
-        self.check_for_id(self._create_args(input), id, occurance)
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.vars.srcurioptions'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('protocol', ['npm'])
     @pytest.mark.parametrize('option', OPTION_MAPPING['npm'])
-    def test_good_npm(self, id, occurance, protocol, option):
+    def test_good_npm(self, id, occurrence, protocol, option):
         input = {
             'oelint_adv_test.bb': self.__generate_sample_code(protocol, option)
         }
-        self.check_for_id(self._create_args(input), id, occurance)
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.vars.srcurioptions'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('protocol', ['npmsw'])
     @pytest.mark.parametrize('option', [x for x in OPTIONS_AVAILABLE if x not in OPTION_MAPPING['npmsw']])
-    def test_bad_npmsw(self, id, occurance, protocol, option):
+    def test_bad_npmsw(self, id, occurrence, protocol, option):
         input = {
             'oelint_adv_test.bb': self.__generate_sample_code(protocol, option)
         }
-        self.check_for_id(self._create_args(input), id, occurance)
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.vars.srcurioptions'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('protocol', ['npmsw'])
     @pytest.mark.parametrize('option', OPTION_MAPPING['npmsw'])
-    def test_good_npmsw(self, id, occurance, protocol, option):
+    def test_good_npmsw(self, id, occurrence, protocol, option):
         input = {
             'oelint_adv_test.bb': self.__generate_sample_code(protocol, option)
         }
-        self.check_for_id(self._create_args(input), id, occurance)
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.vars.srcurioptions'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('protocol', ['svn'])
     @pytest.mark.parametrize('option', [x for x in OPTIONS_AVAILABLE if x not in OPTION_MAPPING['svn']])
-    def test_bad_svn(self, id, occurance, protocol, option):
+    def test_bad_svn(self, id, occurrence, protocol, option):
         input = {
             'oelint_adv_test.bb': self.__generate_sample_code(protocol, option)
         }
-        self.check_for_id(self._create_args(input), id, occurance)
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.vars.srcurioptions'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('protocol', ['svn'])
     @pytest.mark.parametrize('option', OPTION_MAPPING['svn'])
-    def test_good_svn(self, id, occurance, protocol, option):
+    def test_good_svn(self, id, occurrence, protocol, option):
         input = {
             'oelint_adv_test.bb': self.__generate_sample_code(protocol, option)
         }
-        self.check_for_id(self._create_args(input), id, occurance)
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.vars.srcurioptions'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -743,11 +743,11 @@ class TestClassOelintVarsSRCURIOptions(TestBaseClass):
             }
         ],
     )
-    def test_good_conditionals(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_good_conditionals(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.vars.srcurioptions'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -770,11 +770,11 @@ class TestClassOelintVarsSRCURIOptions(TestBaseClass):
             },
         ],
     )
-    def test_good_edgecases_good(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_good_edgecases_good(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.vars.srcurioptions'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -785,11 +785,11 @@ class TestClassOelintVarsSRCURIOptions(TestBaseClass):
             }
         ],
     )
-    def test_good_edgecases_bad(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_good_edgecases_bad(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.vars.srcurioptions'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('input',
         [
             {
@@ -806,5 +806,5 @@ class TestClassOelintVarsSRCURIOptions(TestBaseClass):
             },
         ],
     )
-    def test_type_kmeta_allowed(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_type_kmeta_allowed(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)

--- a/tests/test_class_oelint_vars_srcurisrcrevtag.py
+++ b/tests/test_class_oelint_vars_srcurisrcrevtag.py
@@ -10,7 +10,7 @@ from base import TestBaseClass
 class TestClassOelintVarsSRCURIRevTag(TestBaseClass):
 
     @pytest.mark.parametrize('id', ['oelint.vars.srcurisrcrevtag'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -29,11 +29,11 @@ class TestClassOelintVarsSRCURIRevTag(TestBaseClass):
             }
         ],
     )
-    def test_bad(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_bad(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.vars.srcurisrcrevtag'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -77,5 +77,5 @@ class TestClassOelintVarsSRCURIRevTag(TestBaseClass):
             },
         ],
     )
-    def test_good(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_good(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)

--- a/tests/test_class_oelint_vars_srcuriswildcard.py
+++ b/tests/test_class_oelint_vars_srcuriswildcard.py
@@ -10,7 +10,7 @@ from base import TestBaseClass
 class TestClassOelintVarSRCURIWildcard(TestBaseClass):
 
     @pytest.mark.parametrize('id', ['oelint.var.srcuriwildcard'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -28,11 +28,11 @@ class TestClassOelintVarSRCURIWildcard(TestBaseClass):
             }
         ],
     )
-    def test_bad(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_bad(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.var.srcuriwildcard'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -49,5 +49,5 @@ class TestClassOelintVarSRCURIWildcard(TestBaseClass):
             },
         ],
     )
-    def test_good(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_good(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)

--- a/tests/test_class_oelint_vars_summary80chars.py
+++ b/tests/test_class_oelint_vars_summary80chars.py
@@ -10,7 +10,7 @@ from base import TestBaseClass
 class TestClassOelintVarsSummary80Chars(TestBaseClass):
 
     @pytest.mark.parametrize('id', ['oelint.vars.summary80chars'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -21,11 +21,11 @@ class TestClassOelintVarsSummary80Chars(TestBaseClass):
             },
         ],
     )
-    def test_bad(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_bad(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.vars.summary80chars'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -42,5 +42,5 @@ class TestClassOelintVarsSummary80Chars(TestBaseClass):
             },
         ],
     )
-    def test_good(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_good(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)

--- a/tests/test_class_oelint_vars_summarylinebreaks.py
+++ b/tests/test_class_oelint_vars_summarylinebreaks.py
@@ -10,7 +10,7 @@ from base import TestBaseClass
 class TestClassOelintVarsSummaryLineBreaks(TestBaseClass):
 
     @pytest.mark.parametrize('id', ['oelint.vars.summarylinebreaks'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -21,11 +21,11 @@ class TestClassOelintVarsSummaryLineBreaks(TestBaseClass):
             },
         ],
     )
-    def test_bad(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_bad(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.vars.summarylinebreaks'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -43,5 +43,5 @@ class TestClassOelintVarsSummaryLineBreaks(TestBaseClass):
             },
         ],
     )
-    def test_good(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_good(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)

--- a/tests/test_class_oelint_vars_valuequoted.py
+++ b/tests/test_class_oelint_vars_valuequoted.py
@@ -10,7 +10,7 @@ from base import TestBaseClass
 class TestClassOelintVarsValueQuoted(TestBaseClass):
 
     @pytest.mark.parametrize('id', ['oelint.vars.valuequoted'])
-    @pytest.mark.parametrize('occurance', [2])
+    @pytest.mark.parametrize('occurrence', [2])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -22,11 +22,11 @@ class TestClassOelintVarsValueQuoted(TestBaseClass):
             },
         ],
     )
-    def test_bad(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_bad(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.vars.valuequoted'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -67,5 +67,5 @@ class TestClassOelintVarsValueQuoted(TestBaseClass):
             },
         ],
     )
-    def test_good(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_good(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)


### PR DESCRIPTION
Refactored two typos:

 * occurance -> occurrence
 * occurances -> occurrences

FWIW: This is an awesome tool that I even run in many CIs:
https://github.com/QuakeSaver/oelint-adv/pull/new/bugfix/typo
