### PR TITLE
No blank line if no issues are reported

### DIFF
--- a/oelint_adv/__main__.py
+++ b/oelint_adv/__main__.py
@@ -231,7 +231,9 @@ def main():  # pragma: no cover
 
     if args.output != sys.stderr:
         args.output = open(args.output, 'w')
-    args.output.write('\n'.join([x[1] for x in issues]) + '\n')
+    args.output.write('\n'.join([x[1] for x in issues]))
+    if issues:
+        args.output.write('\n')
     if args.output != sys.stderr:
         args.output.close()
 


### PR DESCRIPTION
The output of oelint-adv if no issues where displayed was still an empty line.
That made the output of e.g. 'find . -name *.bb* -exec oelint-adv --quiet --noinfo {} \;' a bit ugly.
