### PR TITLE
Further refactor

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,7 @@ flake8-ignore =
     E128 # visual indent is too subjective to be enforced
     E261
     I001
-    I003 # prone to false positves
+    I003 # prone to false positives
     I005
     N802
     Q003 # we will go with ' as the default quote

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,19 +1,11 @@
 import os
-import sys
 import tempfile
 import textwrap
-import logging
-
-import pytest
 
 
 class TestBaseClass:
 
     TEST_UNDEFINED_PARAMETER = 'this is an undefined parameter to work around pytest limitations'
-
-    @classmethod
-    def setup_class(cls):
-        sys.path.insert(0, os.path.abspath(os.path.dirname(__file__) + "/../"))
 
     def __pytest_empty_object_fixture(self, _input, default):
         if _input == TestBaseClass.TEST_UNDEFINED_PARAMETER:

--- a/tests/test_class_oelint_append_protvars.py
+++ b/tests/test_class_oelint_append_protvars.py
@@ -1,5 +1,5 @@
 import pytest
-from base import TestBaseClass
+from .base import TestBaseClass
 
 
 class TestClassOelintAppendProtVars(TestBaseClass):

--- a/tests/test_class_oelint_file_inappmsg.py
+++ b/tests/test_class_oelint_file_inappmsg.py
@@ -1,5 +1,5 @@
 import pytest
-from base import TestBaseClass
+from .base import TestBaseClass
 
 
 class TestClassOelintFileUpstreamStatusInAppMsg(TestBaseClass):

--- a/tests/test_class_oelint_file_includenotfound.py
+++ b/tests/test_class_oelint_file_includenotfound.py
@@ -1,5 +1,5 @@
 import pytest
-from base import TestBaseClass
+from .base import TestBaseClass
 
 
 class TestClassOelintFileIncludeNotFound(TestBaseClass):

--- a/tests/test_class_oelint_file_nospaces.py
+++ b/tests/test_class_oelint_file_nospaces.py
@@ -1,5 +1,5 @@
 import pytest
-from base import TestBaseClass
+from .base import TestBaseClass
 
 
 class TestClassOelintFileNoSpaces(TestBaseClass):

--- a/tests/test_class_oelint_file_patchsignedoff.py
+++ b/tests/test_class_oelint_file_patchsignedoff.py
@@ -1,5 +1,5 @@
 import pytest
-from base import TestBaseClass
+from .base import TestBaseClass
 
 
 class TestClassOelintFilePatchSignedOff(TestBaseClass):

--- a/tests/test_class_oelint_file_requireinclude.py
+++ b/tests/test_class_oelint_file_requireinclude.py
@@ -1,5 +1,5 @@
 import pytest
-from base import TestBaseClass
+from .base import TestBaseClass
 
 
 class TestClassOelintFileRequireInclude(TestBaseClass):

--- a/tests/test_class_oelint_file_requirenotfound.py
+++ b/tests/test_class_oelint_file_requirenotfound.py
@@ -1,5 +1,5 @@
 import pytest
-from base import TestBaseClass
+from .base import TestBaseClass
 
 
 class TestClassOelintRequireNotFound(TestBaseClass):

--- a/tests/test_class_oelint_file_underscores.py
+++ b/tests/test_class_oelint_file_underscores.py
@@ -1,5 +1,5 @@
 import pytest
-from base import TestBaseClass
+from .base import TestBaseClass
 
 
 class TestClassOelintFileUnderscores(TestBaseClass):

--- a/tests/test_class_oelint_file_upstreamstatus.py
+++ b/tests/test_class_oelint_file_upstreamstatus.py
@@ -1,5 +1,5 @@
 import pytest
-from base import TestBaseClass
+from .base import TestBaseClass
 
 
 class TestClassOelintFileUpstreamStatus(TestBaseClass):

--- a/tests/test_class_oelint_func_specific.py
+++ b/tests/test_class_oelint_func_specific.py
@@ -1,5 +1,5 @@
 import pytest
-from base import TestBaseClass
+from .base import TestBaseClass
 
 
 class TestClassOelintFuncSpecific(TestBaseClass):

--- a/tests/test_class_oelint_jetm_vars_dependssingleline.py
+++ b/tests/test_class_oelint_jetm_vars_dependssingleline.py
@@ -1,5 +1,5 @@
 import pytest
-from base import TestBaseClass
+from .base import TestBaseClass
 
 
 class TestClassOelintJetmDependsSingleLine(TestBaseClass):

--- a/tests/test_class_oelint_newline_consecutive.py
+++ b/tests/test_class_oelint_newline_consecutive.py
@@ -1,5 +1,5 @@
 import pytest
-from base import TestBaseClass
+from .base import TestBaseClass
 
 
 class TestClassOelintNewlineConsecutive(TestBaseClass):

--- a/tests/test_class_oelint_newline_eof.py
+++ b/tests/test_class_oelint_newline_eof.py
@@ -1,5 +1,5 @@
 import pytest
-from base import TestBaseClass
+from .base import TestBaseClass
 
 
 class TestClassOelintNewlineEOF(TestBaseClass):

--- a/tests/test_class_oelint_spaces_emptyline.py
+++ b/tests/test_class_oelint_spaces_emptyline.py
@@ -1,5 +1,5 @@
 import pytest
-from base import TestBaseClass
+from .base import TestBaseClass
 
 
 class TestClassOelintSpacesEmptyLine(TestBaseClass):

--- a/tests/test_class_oelint_spaces_linebeginning.py
+++ b/tests/test_class_oelint_spaces_linebeginning.py
@@ -1,5 +1,5 @@
 import pytest
-from base import TestBaseClass
+from .base import TestBaseClass
 
 
 class TestClassOelintSpacesLineBeginning(TestBaseClass):

--- a/tests/test_class_oelint_spaces_linecont.py
+++ b/tests/test_class_oelint_spaces_linecont.py
@@ -1,5 +1,5 @@
 import pytest
-from base import TestBaseClass
+from .base import TestBaseClass
 
 
 class TestClassOelintSpacesLineCont(TestBaseClass):

--- a/tests/test_class_oelint_spaces_lineend.py
+++ b/tests/test_class_oelint_spaces_lineend.py
@@ -1,5 +1,5 @@
 import pytest
-from base import TestBaseClass
+from .base import TestBaseClass
 
 
 class TestClassOelintSpacesLineEnd(TestBaseClass):

--- a/tests/test_class_oelint_task_addnotaskbody.py
+++ b/tests/test_class_oelint_task_addnotaskbody.py
@@ -1,5 +1,5 @@
 import pytest
-from base import TestBaseClass
+from .base import TestBaseClass
 
 
 class TestClassOelintTaskAddNoBody(TestBaseClass):

--- a/tests/test_class_oelint_task_anonpython.py
+++ b/tests/test_class_oelint_task_anonpython.py
@@ -1,5 +1,5 @@
 import pytest
-from base import TestBaseClass
+from .base import TestBaseClass
 
 
 class TestClassOelintTaskNoAnonPython(TestBaseClass):

--- a/tests/test_class_oelint_task_customorder.py
+++ b/tests/test_class_oelint_task_customorder.py
@@ -1,5 +1,5 @@
 import pytest
-from base import TestBaseClass
+from .base import TestBaseClass
 
 
 class TestClassOelintTaskCustomOrder(TestBaseClass):

--- a/tests/test_class_oelint_task_docstrings.py
+++ b/tests/test_class_oelint_task_docstrings.py
@@ -1,5 +1,5 @@
 import pytest
-from base import TestBaseClass
+from .base import TestBaseClass
 
 
 class TestClassOelintTaskDocstrings(TestBaseClass):

--- a/tests/test_class_oelint_task_heredocs.py
+++ b/tests/test_class_oelint_task_heredocs.py
@@ -1,5 +1,5 @@
 import pytest
-from base import TestBaseClass
+from .base import TestBaseClass
 
 
 class TestClassOelintTaskHeredocs(TestBaseClass):

--- a/tests/test_class_oelint_task_multifragments.py
+++ b/tests/test_class_oelint_task_multifragments.py
@@ -1,5 +1,5 @@
 import pytest
-from base import TestBaseClass
+from .base import TestBaseClass
 
 
 class TestClassOelintTaskMultiAppends(TestBaseClass):

--- a/tests/test_class_oelint_task_nocp.py
+++ b/tests/test_class_oelint_task_nocp.py
@@ -1,5 +1,5 @@
 import pytest
-from base import TestBaseClass
+from .base import TestBaseClass
 
 
 class TestClassOelintTaskNoCopy(TestBaseClass):

--- a/tests/test_class_oelint_task_nomkdir.py
+++ b/tests/test_class_oelint_task_nomkdir.py
@@ -1,5 +1,5 @@
 import pytest
-from base import TestBaseClass
+from .base import TestBaseClass
 
 
 class TestClassOelintTaskNoMkdir(TestBaseClass):

--- a/tests/test_class_oelint_task_nopythonprefix.py
+++ b/tests/test_class_oelint_task_nopythonprefix.py
@@ -1,5 +1,5 @@
 import pytest
-from base import TestBaseClass
+from .base import TestBaseClass
 
 
 class TestClassOelintTaskNoPythonPrefix(TestBaseClass):

--- a/tests/test_class_oelint_task_pythonprefix.py
+++ b/tests/test_class_oelint_task_pythonprefix.py
@@ -1,5 +1,5 @@
 import pytest
-from base import TestBaseClass
+from .base import TestBaseClass
 
 
 class TestClassOelintTaskPythonPrefix(TestBaseClass):

--- a/tests/test_class_oelint_task_taskorder.py
+++ b/tests/test_class_oelint_task_taskorder.py
@@ -1,5 +1,5 @@
 import pytest
-from base import TestBaseClass
+from .base import TestBaseClass
 
 # -- known order --
 # "do_fetch",

--- a/tests/test_class_oelint_var_bbclassextend.py
+++ b/tests/test_class_oelint_var_bbclassextend.py
@@ -1,5 +1,5 @@
 import pytest
-from base import TestBaseClass
+from .base import TestBaseClass
 
 
 class TestClassOelintVarBBClassExtend(TestBaseClass):

--- a/tests/test_class_oelint_var_filesoverride.py
+++ b/tests/test_class_oelint_var_filesoverride.py
@@ -1,5 +1,5 @@
 import pytest
-from base import TestBaseClass
+from .base import TestBaseClass
 
 
 class TestClassOelintVarFilesOverride(TestBaseClass):

--- a/tests/test_class_oelint_var_improperinherit.py
+++ b/tests/test_class_oelint_var_improperinherit.py
@@ -1,5 +1,5 @@
 import pytest
-from base import TestBaseClass
+from .base import TestBaseClass
 
 
 class TestClassOelintVarImproperInherit(TestBaseClass):

--- a/tests/test_class_oelint_var_licenseremote.py
+++ b/tests/test_class_oelint_var_licenseremote.py
@@ -1,5 +1,5 @@
 import pytest
-from base import TestBaseClass
+from .base import TestBaseClass
 
 
 class TestClassOelintVarLicenseRemoteFile(TestBaseClass):

--- a/tests/test_class_oelint_var_mandatory.py
+++ b/tests/test_class_oelint_var_mandatory.py
@@ -1,5 +1,5 @@
 import pytest
-from base import TestBaseClass
+from .base import TestBaseClass
 
 
 class TestClassOelintVarMandatoryVar(TestBaseClass):

--- a/tests/test_class_oelint_var_multiinclude.py
+++ b/tests/test_class_oelint_var_multiinclude.py
@@ -1,5 +1,5 @@
 import pytest
-from base import TestBaseClass
+from .base import TestBaseClass
 
 
 class TestClassOelintVarMultiInclude(TestBaseClass):

--- a/tests/test_class_oelint_var_multiinherit.py
+++ b/tests/test_class_oelint_var_multiinherit.py
@@ -1,5 +1,5 @@
 import pytest
-from base import TestBaseClass
+from .base import TestBaseClass
 
 
 class TestClassOelintVarMultiInherit(TestBaseClass):

--- a/tests/test_class_oelint_var_nativefilename.py
+++ b/tests/test_class_oelint_var_nativefilename.py
@@ -1,5 +1,5 @@
 import pytest
-from base import TestBaseClass
+from .base import TestBaseClass
 
 
 class TestClassOelintVarNativeFilename(TestBaseClass):

--- a/tests/test_class_oelint_var_nativesdkfilename.py
+++ b/tests/test_class_oelint_var_nativesdkfilename.py
@@ -1,5 +1,5 @@
 import pytest
-from base import TestBaseClass
+from .base import TestBaseClass
 
 
 class TestClassOelintVarNativeSDKFilename(TestBaseClass):

--- a/tests/test_class_oelint_var_order.py
+++ b/tests/test_class_oelint_var_order.py
@@ -1,5 +1,5 @@
 import pytest
-from base import TestBaseClass
+from .base import TestBaseClass
 
 VAR_ORDER = [
     "SUMMARY",

--- a/tests/test_class_oelint_var_override.py
+++ b/tests/test_class_oelint_var_override.py
@@ -1,5 +1,5 @@
 import pytest
-from base import TestBaseClass
+from .base import TestBaseClass
 
 
 class TestClassOelintVarOverride(TestBaseClass):

--- a/tests/test_class_oelint_var_rootfscmd.py
+++ b/tests/test_class_oelint_var_rootfscmd.py
@@ -1,5 +1,5 @@
 import pytest
-from base import TestBaseClass
+from .base import TestBaseClass
 
 
 class TestClassOelintVarRootFSCmd(TestBaseClass):

--- a/tests/test_class_oelint_var_suggested.py
+++ b/tests/test_class_oelint_var_suggested.py
@@ -1,5 +1,5 @@
 import pytest
-from base import TestBaseClass
+from .base import TestBaseClass
 
 
 class TestClassOelintVarSuggestedVar(TestBaseClass):

--- a/tests/test_class_oelint_vars_appendop.py
+++ b/tests/test_class_oelint_vars_appendop.py
@@ -1,5 +1,5 @@
 import pytest
-from base import TestBaseClass
+from .base import TestBaseClass
 
 
 class TestClassOelintVarAppendOp(TestBaseClass):

--- a/tests/test_class_oelint_vars_autorev.py
+++ b/tests/test_class_oelint_vars_autorev.py
@@ -1,5 +1,5 @@
 import pytest
-from base import TestBaseClass
+from .base import TestBaseClass
 
 
 class TestClassOelintVarsAutorev(TestBaseClass):

--- a/tests/test_class_oelint_vars_bbvars.py
+++ b/tests/test_class_oelint_vars_bbvars.py
@@ -1,5 +1,5 @@
 import pytest
-from base import TestBaseClass
+from .base import TestBaseClass
 
 
 class TestClassOelintVarsBBVars(TestBaseClass):

--- a/tests/test_class_oelint_vars_bugtrackerurl.py
+++ b/tests/test_class_oelint_vars_bugtrackerurl.py
@@ -1,5 +1,5 @@
 import pytest
-from base import TestBaseClass
+from .base import TestBaseClass
 
 
 class TestClassOelintVarsBugtrackerIsUrl(TestBaseClass):

--- a/tests/test_class_oelint_vars_dependsappend.py
+++ b/tests/test_class_oelint_vars_dependsappend.py
@@ -1,5 +1,5 @@
 import pytest
-from base import TestBaseClass
+from .base import TestBaseClass
 
 
 class TestClassOelintVarsDependsAppend(TestBaseClass):

--- a/tests/test_class_oelint_vars_dependsordered.py
+++ b/tests/test_class_oelint_vars_dependsordered.py
@@ -1,5 +1,5 @@
 import pytest
-from base import TestBaseClass
+from .base import TestBaseClass
 
 
 class TestClassOelintVarsDependsOrdered(TestBaseClass):

--- a/tests/test_class_oelint_vars_descriptionsame.py
+++ b/tests/test_class_oelint_vars_descriptionsame.py
@@ -1,5 +1,5 @@
 import pytest
-from base import TestBaseClass
+from .base import TestBaseClass
 
 
 class TestClassOelintVarsDescriptionSame(TestBaseClass):

--- a/tests/test_class_oelint_vars_descriptiontoobrief.py
+++ b/tests/test_class_oelint_vars_descriptiontoobrief.py
@@ -1,5 +1,5 @@
 import pytest
-from base import TestBaseClass
+from .base import TestBaseClass
 
 
 class TestClassOelintVarsDescriptionTooBrief(TestBaseClass):

--- a/tests/test_class_oelint_vars_doublemodify.py
+++ b/tests/test_class_oelint_vars_doublemodify.py
@@ -1,5 +1,5 @@
 import pytest
-from base import TestBaseClass
+from .base import TestBaseClass
 
 
 class TestClassOelintVarsDoubleModify(TestBaseClass):

--- a/tests/test_class_oelint_vars_duplicate.py
+++ b/tests/test_class_oelint_vars_duplicate.py
@@ -1,5 +1,5 @@
 import pytest
-from base import TestBaseClass
+from .base import TestBaseClass
 
 
 class TestClassOelintVarsDuplicate(TestBaseClass):

--- a/tests/test_class_oelint_vars_fileextrapaths.py
+++ b/tests/test_class_oelint_vars_fileextrapaths.py
@@ -1,5 +1,5 @@
 import pytest
-from base import TestBaseClass
+from .base import TestBaseClass
 
 
 class TestClassOelintVarsFilextrapaths(TestBaseClass):

--- a/tests/test_class_oelint_vars_fileextrapathsop.py
+++ b/tests/test_class_oelint_vars_fileextrapathsop.py
@@ -1,5 +1,5 @@
 import pytest
-from base import TestBaseClass
+from .base import TestBaseClass
 
 
 class TestClassOelintVarsFilextrapaths(TestBaseClass):

--- a/tests/test_class_oelint_vars_filessetting_double.py
+++ b/tests/test_class_oelint_vars_filessetting_double.py
@@ -1,5 +1,5 @@
 import pytest
-from base import TestBaseClass
+from .base import TestBaseClass
 
 
 class TestClassOelintVarsFileSettingsDouble(TestBaseClass):

--- a/tests/test_class_oelint_vars_filessetting_hidden.py
+++ b/tests/test_class_oelint_vars_filessetting_hidden.py
@@ -1,5 +1,5 @@
 import pytest
-from base import TestBaseClass
+from .base import TestBaseClass
 
 
 class TestClassOelintVarsFileSettingsHidden(TestBaseClass):

--- a/tests/test_class_oelint_vars_homepageping.py
+++ b/tests/test_class_oelint_vars_homepageping.py
@@ -1,5 +1,5 @@
 import pytest
-from base import TestBaseClass
+from .base import TestBaseClass
 
 
 class TestClassOelintVarsHomepagePing(TestBaseClass):

--- a/tests/test_class_oelint_vars_homepageprefix.py
+++ b/tests/test_class_oelint_vars_homepageprefix.py
@@ -1,5 +1,5 @@
 import pytest
-from base import TestBaseClass
+from .base import TestBaseClass
 
 
 class TestClassOelintVarsHomepagePrefix(TestBaseClass):

--- a/tests/test_class_oelint_vars_inconspaces.py
+++ b/tests/test_class_oelint_vars_inconspaces.py
@@ -1,5 +1,5 @@
 import pytest
-from base import TestBaseClass
+from .base import TestBaseClass
 
 
 class TestClassOelintVarsInconSpaces(TestBaseClass):

--- a/tests/test_class_oelint_vars_insaneskip.py
+++ b/tests/test_class_oelint_vars_insaneskip.py
@@ -1,5 +1,5 @@
 import pytest
-from base import TestBaseClass
+from .base import TestBaseClass
 
 
 class TestClassOelintVarsInsaneSkip(TestBaseClass):

--- a/tests/test_class_oelint_vars_licensefileprefix.py
+++ b/tests/test_class_oelint_vars_licensefileprefix.py
@@ -1,5 +1,5 @@
 import pytest
-from base import TestBaseClass
+from .base import TestBaseClass
 
 
 class TestClassOelintVarsLicenseFilePrefix(TestBaseClass):

--- a/tests/test_class_oelint_vars_listappend.py
+++ b/tests/test_class_oelint_vars_listappend.py
@@ -1,5 +1,5 @@
 import pytest
-from base import TestBaseClass
+from .base import TestBaseClass
 
 
 class TestClassOelintVarsListAppend(TestBaseClass):

--- a/tests/test_class_oelint_vars_misspell.py
+++ b/tests/test_class_oelint_vars_misspell.py
@@ -1,5 +1,5 @@
 import pytest
-from base import TestBaseClass
+from .base import TestBaseClass
 
 
 class TestClassOelintVarsMispell(TestBaseClass):

--- a/tests/test_class_oelint_vars_multilineident.py
+++ b/tests/test_class_oelint_vars_multilineident.py
@@ -1,5 +1,5 @@
 import pytest
-from base import TestBaseClass
+from .base import TestBaseClass
 
 
 class TestClassOelintVarsMultilineIdent(TestBaseClass):

--- a/tests/test_class_oelint_vars_notneededspace.py
+++ b/tests/test_class_oelint_vars_notneededspace.py
@@ -1,5 +1,5 @@
 import pytest
-from base import TestBaseClass
+from .base import TestBaseClass
 
 
 class TestClassOelintVarsNotNeededSpace(TestBaseClass):

--- a/tests/test_class_oelint_vars_notrailingslash.py
+++ b/tests/test_class_oelint_vars_notrailingslash.py
@@ -1,5 +1,5 @@
 import pytest
-from base import TestBaseClass
+from .base import TestBaseClass
 
 
 class TestClassOelintVarsNoTrailingSlash(TestBaseClass):

--- a/tests/test_class_oelint_vars_pathhardcode.py
+++ b/tests/test_class_oelint_vars_pathhardcode.py
@@ -1,7 +1,7 @@
 import os
 
 import pytest
-from base import TestBaseClass
+from .base import TestBaseClass
 
 
 class TestClassOelintVarsPathHardcode(TestBaseClass):

--- a/tests/test_class_oelint_vars_pbpusage.py
+++ b/tests/test_class_oelint_vars_pbpusage.py
@@ -1,5 +1,5 @@
 import pytest
-from base import TestBaseClass
+from .base import TestBaseClass
 
 
 class TestClassOelintVarsPBPUsage(TestBaseClass):

--- a/tests/test_class_oelint_vars_pkgspecific.py
+++ b/tests/test_class_oelint_vars_pkgspecific.py
@@ -1,5 +1,5 @@
 import pytest
-from base import TestBaseClass
+from .base import TestBaseClass
 
 
 class TestClassOelintVarsPKGSpecific(TestBaseClass):

--- a/tests/test_class_oelint_vars_pnbpnusage.py
+++ b/tests/test_class_oelint_vars_pnbpnusage.py
@@ -1,5 +1,5 @@
 import pytest
-from base import TestBaseClass
+from .base import TestBaseClass
 
 
 class TestClassOelintVarsPNBPNUsage(TestBaseClass):

--- a/tests/test_class_oelint_vars_pnusagedis.py
+++ b/tests/test_class_oelint_vars_pnusagedis.py
@@ -1,5 +1,5 @@
 import pytest
-from base import TestBaseClass
+from .base import TestBaseClass
 
 
 class TestClassOelintVarsPNUsageDiscouraged(TestBaseClass):

--- a/tests/test_class_oelint_vars_sectionlowercase.py
+++ b/tests/test_class_oelint_vars_sectionlowercase.py
@@ -1,5 +1,5 @@
 import pytest
-from base import TestBaseClass
+from .base import TestBaseClass
 
 
 class TestClassOelintVarsSectionLowerCase(TestBaseClass):

--- a/tests/test_class_oelint_vars_spaceassignment.py
+++ b/tests/test_class_oelint_vars_spaceassignment.py
@@ -1,5 +1,5 @@
 import pytest
-from base import TestBaseClass
+from .base import TestBaseClass
 
 
 class TestClassOelintVarsSectionLowerCase(TestBaseClass):

--- a/tests/test_class_oelint_vars_specific.py
+++ b/tests/test_class_oelint_vars_specific.py
@@ -1,5 +1,5 @@
 import pytest
-from base import TestBaseClass
+from .base import TestBaseClass
 
 
 class TestClassOelintVarsSpecific(TestBaseClass):

--- a/tests/test_class_oelint_vars_srcuriappend.py
+++ b/tests/test_class_oelint_vars_srcuriappend.py
@@ -1,5 +1,5 @@
 import pytest
-from base import TestBaseClass
+from .base import TestBaseClass
 
 
 class TestClassOelintVarsSRCURIappend(TestBaseClass):

--- a/tests/test_class_oelint_vars_srcuridomains.py
+++ b/tests/test_class_oelint_vars_srcuridomains.py
@@ -1,5 +1,5 @@
 import pytest
-from base import TestBaseClass
+from .base import TestBaseClass
 
 
 class TestClassOelintVarsSRCURIdomains(TestBaseClass):

--- a/tests/test_class_oelint_vars_srcurifile.py
+++ b/tests/test_class_oelint_vars_srcurifile.py
@@ -1,5 +1,5 @@
 import pytest
-from base import TestBaseClass
+from .base import TestBaseClass
 
 
 class TestClassOelintVarsSRCURIfile(TestBaseClass):

--- a/tests/test_class_oelint_vars_srcurigittag.py
+++ b/tests/test_class_oelint_vars_srcurigittag.py
@@ -1,5 +1,5 @@
 import pytest
-from base import TestBaseClass
+from .base import TestBaseClass
 
 
 class TestClassOelintVarsSRCURIGitTag(TestBaseClass):

--- a/tests/test_class_oelint_vars_srcurioptions.py
+++ b/tests/test_class_oelint_vars_srcurioptions.py
@@ -1,5 +1,5 @@
 import pytest
-from base import TestBaseClass
+from .base import TestBaseClass
 
 OPTIONS_AVAILABLE =  [
     "apply",

--- a/tests/test_class_oelint_vars_srcurisrcrevtag.py
+++ b/tests/test_class_oelint_vars_srcurisrcrevtag.py
@@ -1,5 +1,5 @@
 import pytest
-from base import TestBaseClass
+from .base import TestBaseClass
 
 
 class TestClassOelintVarsSRCURIRevTag(TestBaseClass):

--- a/tests/test_class_oelint_vars_srcuriswildcard.py
+++ b/tests/test_class_oelint_vars_srcuriswildcard.py
@@ -1,5 +1,5 @@
 import pytest
-from base import TestBaseClass
+from .base import TestBaseClass
 
 
 class TestClassOelintVarSRCURIWildcard(TestBaseClass):

--- a/tests/test_class_oelint_vars_summary80chars.py
+++ b/tests/test_class_oelint_vars_summary80chars.py
@@ -1,5 +1,5 @@
 import pytest
-from base import TestBaseClass
+from .base import TestBaseClass
 
 
 class TestClassOelintVarsSummary80Chars(TestBaseClass):

--- a/tests/test_class_oelint_vars_summarylinebreaks.py
+++ b/tests/test_class_oelint_vars_summarylinebreaks.py
@@ -1,5 +1,5 @@
 import pytest
-from base import TestBaseClass
+from .base import TestBaseClass
 
 
 class TestClassOelintVarsSummaryLineBreaks(TestBaseClass):

--- a/tests/test_class_oelint_vars_valuequoted.py
+++ b/tests/test_class_oelint_vars_valuequoted.py
@@ -1,5 +1,5 @@
 import pytest
-from base import TestBaseClass
+from .base import TestBaseClass
 
 
 class TestClassOelintVarsValueQuoted(TestBaseClass):


### PR DESCRIPTION
Use top level imports and install the package before testing. Tests execute about 10-20% faster as repeated imports are suprisigly expensive.
Also this cleans up and simplifies testing a little.