### PR TITLE
refactor short variable names

### DIFF
--- a/oelint_adv/rule_base/rule_var_src_uri.py
+++ b/oelint_adv/rule_base/rule_var_src_uri.py
@@ -126,7 +126,7 @@ class VarSRCUriOptions(Rule):
             ],
         }
 
-    def __analyse(self, i, _input, _index):
+    def __analyse(self, item, _input, _index):
         _url = get_scr_components(_input)
         res = []
         if 'scheme' not in _url:
@@ -134,7 +134,7 @@ class VarSRCUriOptions(Rule):
         # For certain types of file:// url parsing fails
         # ignore those
         if _url['scheme'] not in self._valid_options.keys() and not _input.strip().startswith('file://') and _url['scheme']:
-            res += self.finding(i.Origin, i.InFileLine + _index,
+            res += self.finding(item.Origin, item.InFileLine + _index,
                                 'Fetcher \'{a}\' is not known'.format(a=_url['scheme']))
         else:
             for k, v in _url['options'].items():
@@ -143,7 +143,7 @@ class VarSRCUriOptions(Rule):
                 if k == 'type' and v == 'kmeta':
                     continue  # linux-yocto uses this option to indicate kernel metadata sources
                 if k not in self._valid_options[_url['scheme']] + self._general_options:
-                    res += self.finding(i.Origin, i.InFileLine + _index,
+                    res += self.finding(item.Origin, item.InFileLine + _index,
                                         'Option \'{a}\' is not known with this fetcher type'.format(a=k))
         return res
 
@@ -151,13 +151,13 @@ class VarSRCUriOptions(Rule):
         res = []
         items = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
                                   attribute=Variable.ATTR_VAR, attributeValue='SRC_URI')
-        for i in items:
-            if any([i.Flag.endswith(x) for x in ['md5sum', 'sha256sum']]):
+        for item in items:
+            if any([item.Flag.endswith(x) for x in ['md5sum', 'sha256sum']]):
                 # These are just the hashes
                 continue
-            lines = [y.strip('"') for y in i.get_items() if y]
+            lines = [y.strip('"') for y in item.get_items() if y]
             for x in lines:
                 if x == INLINE_BLOCK:
                     continue
-                res += self.__analyse(i, x, lines.index(x))
+                res += self.__analyse(item, x, lines.index(x))
         return res

--- a/oelint_adv/rule_base/rule_var_src_uri_append.py
+++ b/oelint_adv/rule_base/rule_var_src_uri_append.py
@@ -17,10 +17,10 @@ class VarSRCUriGitTag(Rule):
 
         items = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
                                   attribute=Variable.ATTR_VAR, attributeValue='SRC_URI')
-        for i in items:
-            if any([i.Flag.endswith(x) for x in ['md5sum', 'sha256sum']]):
+        for item in items:
+            if any([item.Flag.endswith(x) for x in ['md5sum', 'sha256sum']]):
                 # These are just the hashes
                 continue
-            if i.VarOp in [' += ']:
-                res += self.finding(i.Origin, i.InFileLine)
+            if item.VarOp in [' += ']:
+                res += self.finding(item.Origin, item.InFileLine)
         return res

--- a/oelint_adv/rule_base/rule_var_src_uri_domains.py
+++ b/oelint_adv/rule_base/rule_var_src_uri_domains.py
@@ -16,13 +16,13 @@ class VarSRCUriOptions(Rule):
                                   attribute=Variable.ATTR_VAR, attributeValue='SRC_URI')
 
         _domains = set()
-        for i in items:
-            for u in [x.strip('\'').strip() for x in i.get_items()]:
+        for item in items:
+            for u in [x.strip('\'').strip() for x in item.get_items()]:
                 if u == INLINE_BLOCK:
                     continue
                 _url = get_scr_components(u)
                 if _url['scheme'] and _url['scheme'] not in ['file']:
                     _domains.add(_url['src'].split('/')[0])
         if len(_domains) > 1:
-            res += self.finding(i.Origin, i.InFileLine)
+            res += self.finding(item.Origin, item.InFileLine)
         return res

--- a/oelint_adv/rule_base/rule_var_src_uri_file.py
+++ b/oelint_adv/rule_base/rule_var_src_uri_file.py
@@ -15,20 +15,20 @@ class VarSRCUriGitTag(Rule):
         items = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
                                   attribute=Variable.ATTR_VAR, attributeValue='SRC_URI')
         _fetcher = []
-        for i in items:
-            if any([i.Flag.endswith(x) for x in ['md5sum', 'sha256sum']]):
+        for item in items:
+            if any([item.Flag.endswith(x) for x in ['md5sum', 'sha256sum']]):
                 # These are just the hashes
                 continue
-            lines = [y.strip('"') for y in i.get_items() if y]
+            lines = [y.strip('"') for y in item.get_items() if y]
 
             for x in lines:
                 if x == INLINE_BLOCK:
-                    _fetcher.append(('inline', i.InFileLine))
+                    _fetcher.append(('inline', item.InFileLine))
                     continue
                 _url = get_scr_components(x)
                 if _url['scheme']:
-                    _fetcher.append((_url['scheme'], i.InFileLine))
+                    _fetcher.append((_url['scheme'], item.InFileLine))
         if _fetcher:
             if any(x[0] != 'file' for x in _fetcher) and _fetcher[0][0] == 'file':
-                res += self.finding(i.Origin, _fetcher[0][1])
+                res += self.finding(item.Origin, _fetcher[0][1])
         return res

--- a/oelint_adv/rule_base/rule_var_src_uri_gittag.py
+++ b/oelint_adv/rule_base/rule_var_src_uri_gittag.py
@@ -14,15 +14,15 @@ class VarSRCUriGitTag(Rule):
         res = []
         items = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
                                   attribute=Variable.ATTR_VAR, attributeValue='SRC_URI')
-        for i in items:
-            if any([i.Flag.endswith(x) for x in ['md5sum', 'sha256sum']]):
+        for item in items:
+            if any([item.Flag.endswith(x) for x in ['md5sum', 'sha256sum']]):
                 # These are just the hashes
                 continue
-            lines = [y.strip('\'') for y in i.get_items() if y]
+            lines = [y.strip('\'') for y in item.get_items() if y]
             for x in lines:
                 if x == INLINE_BLOCK:
                     continue
                 _url = get_scr_components(x)
                 if _url['scheme'] in ['git'] and 'tag' in _url['options']:
-                    res += self.finding(i.Origin, i.InFileLine)
+                    res += self.finding(item.Origin, item.InFileLine)
         return res

--- a/oelint_adv/rule_base/rule_var_src_uri_srcrevtag.py
+++ b/oelint_adv/rule_base/rule_var_src_uri_srcrevtag.py
@@ -14,11 +14,11 @@ class VarSRCUriSRCREVTag(Rule):
         res = []
         items = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
                                   attribute=Variable.ATTR_VAR, attributeValue='SRC_URI')
-        for i in items:
-            if any([i.Flag.endswith(x) for x in ['md5sum', 'sha256sum']]):
+        for item in items:
+            if any([item.Flag.endswith(x) for x in ['md5sum', 'sha256sum']]):
                 # These are just the hashes
                 continue
-            lines = [y.strip('"') for y in i.get_items() if y]
+            lines = [y.strip('"') for y in item.get_items() if y]
             for x in lines:
                 if x == INLINE_BLOCK:
                     continue
@@ -32,5 +32,5 @@ class VarSRCUriSRCREVTag(Rule):
                     else:
                         _srcrevs = [x for x in _srcrevs if not x.SubItems]
                     if any(_srcrevs):
-                        res += self.finding(i.Origin, i.InFileLine)
+                        res += self.finding(item.Origin, item.InFileLine)
         return res

--- a/oelint_adv/rule_base/rule_var_src_uri_wildcard.py
+++ b/oelint_adv/rule_base/rule_var_src_uri_wildcard.py
@@ -14,12 +14,12 @@ class VarSRCURIWildcard(Rule):
         res = []
         _items = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
                                    attribute=Variable.ATTR_VAR, attributeValue='SRC_URI')
-        for i in _items:
-            for f in [x.strip('\'') for x in i.get_items() if x]:
+        for item in _items:
+            for f in [x.strip('\'') for x in item.get_items() if x]:
                 if f == INLINE_BLOCK:
                     continue
                 components = get_scr_components(f)
                 if components['scheme'] == 'file':
                     if any([x for x in ['*'] if x in components['src']]):
-                        res += self.finding(i.Origin, i.InFileLine)
+                        res += self.finding(item.Origin, item.InFileLine)
         return res


### PR DESCRIPTION
A lot of single character variable names have been used. These should be fixed as it hempers reading the code a lot. A couple of fixes along the way.