### PR TITLE
CLI: add configuration file option

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,36 @@ The following placeholder symbols will be automatically replaced
 | {severity} | severity of the finding    |
 | {id}       | error-ID of the finding    |
 | {msg}      | description of the finding |
+
+## Configuration file
+
+You can define your own global or project wide defaults for all CLI parameters with an ini-style configuration file.
+
+In the following order files are probed
+
+* file pointed to by environment variable `OELINT_CONFIG`
+* file `.oelint.cfg` in current work directory
+* file `.oelint.cfg` in your `HOME` directory
+
+Explicitly passed options to CLI are always chosen over the defaults defined by the configuration file
+
+### File format
+
+```ini
+[oelint]
+# this will set the --nowarn parameter automatically
+nowarn = True
+# this will set A + B as suppress item
+# use indent (tab) and line breaks for multiple items
+suppress = 
+  A
+  B
+# this will set messageformat parameter
+messageformat = {severity}:{id}:{msg}
+```
+
+You can find an example file [here](docs/.oelint.cfg.example)
+
 ## vscode extension
 
 Find the extension in the [marketplace](https://marketplace.visualstudio.com/items?itemName=kweihmann.oelint-vscode), or search for `oelint-vscode`.

--- a/docs/.oelint.cfg.example
+++ b/docs/.oelint.cfg.example
@@ -1,0 +1,7 @@
+[oelint]
+messageformat={severity}:{id}:{msg}
+suppress=
+    oelint.tabs.notabs
+    oelint.task.docstrings
+noinfo=True
+exit-zero=True

--- a/tests/test_configfile.py
+++ b/tests/test_configfile.py
@@ -1,0 +1,206 @@
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))
+
+from base import TestBaseClass  # noqa
+
+
+class TestConfigFile(TestBaseClass):
+
+    @pytest.mark.parametrize('input',
+                             [
+                                 {
+                                     'oelint adv-test.bb': 'VAR = "1"',
+                                 },
+                             ],
+                             )
+    def test_config_file_environ(self, input):
+        # Test the default
+        _args = self._create_args(input)
+
+        assert not _args.nowarn
+
+        # test the override from config file
+        # here loaded via environment variable
+        _cstfile = self._create_tempfile('oelint.cfg', '[oelint]\nnowarn=True')
+        os.environ['OELINT_CONFIG'] = _cstfile
+        _args = self._create_args(input)
+        del os.environ['OELINT_CONFIG']
+        
+        assert _args.nowarn
+
+    @pytest.mark.parametrize('input',
+                             [
+                                 {
+                                     'oelint adv-test.bb': 'VAR = "1"',
+                                 },
+                             ],
+                             )
+    def test_config_file_home(self, input):
+        # Test the default
+        _args = self._create_args(input)
+
+        assert not _args.nowarn
+
+        # test the override from config file
+        # here loaded via home folder
+        _cstfile = self._create_tempfile(
+            '.oelint.cfg', '[oelint]\nnowarn=True')
+        os.environ['HOME'] = os.path.dirname(_cstfile)
+        _args = self._create_args(input)
+
+        assert _args.nowarn
+
+    @pytest.mark.parametrize('input',
+                             [
+                                 {
+                                     'oelint adv-test.bb': 'VAR = "1"',
+                                 },
+                             ],
+                             )
+    def test_config_file_workdir(self, input):
+        # Test the default
+        _args = self._create_args(input)
+
+        assert not _args.nowarn
+
+        # test the override from config file
+        # here loaded from current workdir
+        _cstfile = self._create_tempfile(
+            '.oelint.cfg', '[oelint]\nnowarn=True')
+
+        _cwd = os.getcwd()
+        os.chdir(os.path.dirname(_cstfile))
+        _args = self._create_args(input)
+        os.chdir(_cwd)
+
+        assert _args.nowarn
+
+    @pytest.mark.parametrize('input',
+                             [
+                                 {
+                                     'oelint adv-test.bb': 'VAR = "1"',
+                                 },
+                             ],
+                             )
+    def test_config_file_boolean_options(self, input):
+        # Test if the following options are auto converted
+        # to boolean arguments
+        for _option in [
+            'color',
+            'exit-zero',
+            'fix',
+            'nobackup',
+            'noinfo',
+            'nowarn',
+            'print-rulefile',
+            'quiet',
+            'relpaths',
+        ]:
+            _cstfile = self._create_tempfile(
+                '.oelint.cfg', '[oelint]\n{item}=True'.format(item=_option))
+            os.environ['OELINT_CONFIG'] = _cstfile
+            _args = self._create_args(input)
+            del os.environ['OELINT_CONFIG']
+
+            assert isinstance(getattr(_args, _option), bool)
+
+    @pytest.mark.parametrize('input',
+                             [
+                                 {
+                                     'oelint adv-test.bb': 'VAR = "1"',
+                                 },
+                             ],
+                             )
+    def test_config_file_no_convert(self, input):
+        # Test if the following options remain untouched
+        for _option in [
+            'output',
+            'addrules',
+            'customrules',
+            'messageformat',
+        ]:
+            _cstfile = self._create_tempfile(
+                '.oelint.cfg', '[oelint]\n{item}=True'.format(item=_option))
+            os.environ['OELINT_CONFIG'] = _cstfile
+            _args = self._create_args(input)
+            del os.environ['OELINT_CONFIG']
+
+            assert getattr(_args, _option) == 'True'
+
+    @pytest.mark.parametrize('input',
+                             [
+                                 {
+                                     'oelint adv-test.bb': 'VAR = "1"',
+                                 },
+                             ],
+                             )
+    def test_config_file_multiple(self, input):
+        # Test if the following options are converted to lists
+        for _option in [
+            'suppress'
+        ]:
+            _cstfile = self._create_tempfile(
+                '.oelint.cfg', '[oelint]\n{item}=\t+True\n\t-False'.format(item=_option))
+            os.environ['OELINT_CONFIG'] = _cstfile
+            _args = self._create_args(input)
+
+            assert isinstance(getattr(_args, _option), list)
+            assert getattr(_args, _option) == ['+True', '-False']
+
+    @pytest.mark.parametrize('input',
+                        [
+                            {
+                                'oelint adv-test.bb': 'VAR = "1"',
+                            },
+                        ],
+                        )
+    def test_config_file_cli_always_wins(self, input):
+        _cstfile = self._create_tempfile(
+            '.oelint.cfg', '[oelint]\suppress=B')
+        os.environ['OELINT_CONFIG'] = _cstfile
+        _args = self._create_args(input, extraopts=['--suppress=A'])
+        del os.environ['OELINT_CONFIG']
+
+        assert getattr(_args, 'suppress') == ['A']
+
+    @pytest.mark.parametrize('input',
+                    [
+                        {
+                            'oelint adv-test.bb': 'VAR = "1"',
+                        },
+                    ],
+                    )
+    def test_config_file_messageformat(self, input):
+        _cstfile = self._create_tempfile(
+            '.oelint.cfg', '[oelint]\nmessageformat={severity}-{id}-{msg}')
+        os.environ['OELINT_CONFIG'] = _cstfile
+        _args = self._create_args(input)
+        del os.environ['OELINT_CONFIG']
+
+        assert getattr(_args, 'messageformat') == '{severity}-{id}-{msg}'
+
+    @pytest.mark.parametrize('input',
+                            [
+                                {
+                                    'oelint adv-test.bb': 'VAR = "1"',
+                                },
+                            ],
+                            )
+    def test_config_file_environ_broken(self, input):
+        # Test the default
+        _args = self._create_args(input)
+
+        assert not _args.nowarn
+
+        # test the override from config file
+        # here loaded via environment variable but with a broken file
+        _cstfile = self._create_tempfile('oelint.cfg', '[oel]\nnowarn=')
+        os.environ['OELINT_CONFIG'] = _cstfile
+        _args = self._create_args(input)
+        del os.environ['OELINT_CONFIG']
+        
+        assert not _args.nowarn


### PR DESCRIPTION
add an option for the user to define an ini-style config file
in the current workspace, or HOME dir or at OELINT_CONFIG.
Parameter set in this file override the default choices from argparse

Closes #279

Signed-off-by: Konrad Weihmann <kweihmann@outlook.com>

# Pull request checklist

## Bugfix

- [ ] A testcase was added to test the behavior

## New feature

- [x] A testcase was added to test the behavior
- [x] New functions are documented with docstrings
- [x] No debug code is left
- [x] README.md was updated to reflect the changes (check even if n.a.)
