### PR TITLE
Feature/codespell

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -22,6 +22,9 @@ jobs:
         pip install --upgrade setuptools 
         pip install -r requirements.txt
         pip install -r requirements-dev.txt
+    - name: linter (codespell)
+      run: codespell oelint_adv docs setup.py README.md
+      shell: bash
     - name: test (pytest)
       run: pytest
       shell: bash

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -23,7 +23,7 @@ jobs:
         pip install -r requirements.txt
         pip install -r requirements-dev.txt
     - name: linter (codespell)
-      run: codespell oelint_adv docs setup.py README.md
+      run: pre-commit run --all-files
       shell: bash
     - name: test (pytest)
       run: pytest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+fail_fast: true
+repos:
+
+- repo: https://github.com/codespell-project/codespell
+  rev: v2.1.0
+  hooks:
+  - id: codespell
+    args:
+      - --skip=*.lock,tests/test_class_oelint_vars_misspell.py
+      # Provide a comma separated list of ignored words here:
+      - -L=mispell

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Rules marked with **[S]** can have multiple sub-IDs
 * oelint.task.order - Order of tasks **[S]**
 * oelint.task.pythonprefix - Tasks containing python code should be prefixed with 'python' in function header
 * oelint.var.bbclassextend - Use BBCLASSEXTEND when possible
-* oelint.var.filesoverride - FILES_* variables should not be overriden
+* oelint.var.filesoverride - FILES_* variables should not be overridden
 * oelint.var.improperinherit - Warn about improperly named inherits
 * oelint.var.licenseremotefile - License shall be a file in remote source not a local file
 * oelint.var.mandatoryvar - Check for mandatory variables **[S]**
@@ -252,7 +252,7 @@ class FooMagicRule(Rule):
         return res
 
     # To provide automatic fixing capability
-    # add the following optinal function
+    # add the following optional function
     def fix(self, _file, stash):
         res = []
         items = stash.GetItemsFor(filename=_file)

--- a/docs/rule_example.py
+++ b/docs/rule_example.py
@@ -16,7 +16,7 @@ class FooMagicRule(Rule):
         return res
 
     # To provide automatic fixing capability
-    # add the following optinal function
+    # add the following optional function
     def fix(self, _file, stash):
         res = []
         items = stash.GetItemsFor(filename=_file)

--- a/oelint_adv/rule_base/rule_file_patch_inappropriatemsg.py
+++ b/oelint_adv/rule_base/rule_file_patch_inappropriatemsg.py
@@ -10,7 +10,7 @@ class FilePatchIsUpstreamStatusInAppMsg(Rule):
     def __init__(self):
         super().__init__(id='oelint.file.inappropriatemsg',
                          severity='info',
-                         message='Patch \'{FILE}\' with Upstream-Status Inappropriate has to have a reasoning appended in [], choosen from {choices}')
+                         message='Patch \'{FILE}\' with Upstream-Status Inappropriate has to have a reasoning appended in [], chosen from {choices}')
 
     def _get_recipe(self, items, path):
         # Find matching SRC_URI assignment

--- a/oelint_adv/rule_base/rule_vars_listappend.py
+++ b/oelint_adv/rule_base/rule_vars_listappend.py
@@ -18,7 +18,7 @@ class VarListAppend(Rule):
             if not any(i.VarName.startswith(x) for x in needles):
                 continue
             if i.VarName.startswith('FILESEXTRAPATHS'):
-                # Catched by the `FILES` above but this list is colon separated.
+                # Caught by the `FILES` above but this list is colon separated.
                 continue
             ops = i.AppendOperation()
             if not i.VarValue.startswith('" ') and any(x in ops for x in ['append', ' .= ']):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,3 +13,4 @@ pytest-sugar >=0.9.0, <2.0.0
 pytest-tldr >=0.2.0, <2.0.0
 wemake-python-styleguide >=0.15.2, <2.0.0
 codespell >=2.1.0, <3.0.0
+pre-commit >=2.14.0, <3.0.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,3 +12,4 @@ pytest-socket >=0.4.0, <2.0.0
 pytest-sugar >=0.9.0, <2.0.0
 pytest-tldr >=0.2.0, <2.0.0
 wemake-python-styleguide >=0.15.2, <2.0.0
+codespell >=2.1.0, <3.0.0

--- a/tests/test_class_oelint_var_nativesdkfilename.py
+++ b/tests/test_class_oelint_var_nativesdkfilename.py
@@ -5,7 +5,7 @@ from .base import TestBaseClass
 class TestClassOelintVarNativeSDKFilename(TestBaseClass):
 
     @pytest.mark.parametrize('id', ['oelint.var.nativesdkfilename'])
-    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -16,11 +16,11 @@ class TestClassOelintVarNativeSDKFilename(TestBaseClass):
             }
         ],
     )
-    def test_bad(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_bad(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.var.nativesdkfilename'])
-    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('input', 
         [
             {
@@ -31,5 +31,5 @@ class TestClassOelintVarNativeSDKFilename(TestBaseClass):
             },
         ],
     )
-    def test_good(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_good(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)


### PR DESCRIPTION
Typos are super unimportant for the programmatic workflow. Still, they come with a taste... I added `codespell` which works great for catching the most common typos in comments.

@priv-kweihmann please check the `oelint.vars.mis(s)pell` typo. Fixing this in `README.md` / code will technically be a breaking API change, in case this has been modified from it's default behaviour in a users config file. This can be added to a codespell dict for ignoring certain cases. Or we fix it and kindly ask to update the local config file (IF anybody complains).

Or we keep it with a grain of irony that there is a typo in `misspell` hahaha