### PR TITLE
Add note regarding options containing '-'

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,8 @@ suppress =
 messageformat = {severity}:{id}:{msg}
 ```
 
+**NOTE:** CLI parameters containing a `-` must use `_` in the configuration file.
+
 You can find an example file [here](docs/.oelint.cfg.example)
 
 ## vscode extension

--- a/docs/.oelint.cfg.example
+++ b/docs/.oelint.cfg.example
@@ -4,4 +4,4 @@ suppress=
     oelint.tabs.notabs
     oelint.task.docstrings
 noinfo=True
-exit-zero=True
+exit_zero=True


### PR DESCRIPTION
Related to #283. Adds a note about config file parameters containing a `-` and updates the example accordingly.

Probably related: https://bugs.python.org/msg164968

