### PR TITLE
Pip cache enabled and shell overrides removed

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -5,6 +5,9 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
     strategy:
       max-parallel: 5
       matrix:

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -24,22 +24,17 @@ jobs:
         pip install -r requirements-dev.txt
     - name: linter (codespell)
       run: pre-commit run --all-files
-      shell: bash
     - name: test (pytest)
       run: pytest
-      shell: bash
     - name: build
       run: python3 setup.py build sdist
-      shell: bash
     - name: install
       run: python3 setup.py install --user
-      shell: bash
     - name: test (installed)
       run: |
         oelint-adv --help
         tar -tvf dist/oelint_adv-*.tar.gz | grep LICENSE
         tar -tvf dist/oelint_adv-*.tar.gz | grep README.md
-      shell: bash
     - if: matrix.python-version == 3.7 && github.repository == 'priv-kweihmann/oelint-adv' && github.event_name == 'push'
       name: Trigger nittymcpick-oelint
       run: |

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -16,6 +16,7 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+        cache: 'pip'
     - name: prepare
       run: |
         python3 -m pip install --upgrade pip


### PR DESCRIPTION
- Enable pip cache
- Remove shell override (bash is [default](https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#jobsjob_idstepsshell) on all non-windows platforms)