### PR TITLE
Keep relative path to fix ValueError when sorting by filenames

### DIFF
--- a/oelint_adv/__main__.py
+++ b/oelint_adv/__main__.py
@@ -217,7 +217,7 @@ def group_files(files):
             _filename_key = os.path.basename(_filename)
         if _filename_key not in res:  # pragma: no cover
             res[_filename_key] = set()
-        res[_filename_key].add(os.path.abspath(f))
+        res[_filename_key].add(f)
 
     # second round now for the bbappend files
     for f in files:


### PR DESCRIPTION
ee585dca16ae07fe066c8c1154ea733e18e59a12 introduced changes that result
in an ValueError: "<filename> not in list" when sorting the filenames
at the end of the group_files function.

This reverts the resolution of f to an absolute path, which would
otherwise lead to an inconsistance as the function uses relative paths
everywhere else.

# Pull request checklist

## Bugfix

- [x] ~~A testcase was added to test the behavior~~ The change is already tested, i.e. still 100% coverage.

## New feature

- [ ] A testcase was added to test the behavior
- [ ] New functions are documented with docstrings
- [ ] No debug code is left
- [ ] README.md was updated to reflect the changes (check even if n.a.)
