### PR TITLE
README.md: escape special characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,10 +187,11 @@ Rules marked with **[S]** can have multiple sub-IDs
 * oelint.vars.notrailingslash - Variable shall not end on a slash
 * oelint.vars.overrideappend - Check correct order of append/prepend on variables with override syntax
 * oelint.vars.pathhardcode - Warn about the usage of hardcoded paths **[S]**
-* oelint.vars.pbpusage - ${BP} should be used instead of ${P} **[F]**
+* oelint.vars.pbpusage - \$\{BP\} should be used instead of \$\{P\} **[F]**
 * oelint.vars.pkgspecific - Variable is package-specific, but isn't set in that way **[S]**
-* oelint.vars.pnbpnusage - ${BPN} should be used instead of ${PN} **[F]**
-* oelint.vars.pnusagediscouraged - Variable shouldn't contain ${PN} or ${BPN}
+* oelint.vars.pnbpnusage - \$\{BPN\} should be used instead of \$\{PN\} **[F]**
+* oelint.vars.pnusagediscouraged - Variable shouldn't contain \$\{PN\} or
+* \$\{BPN\}
 * oelint.vars.sectionlowercase - SECTION should be lowercase only **[F]**
 * oelint.vars.spacesassignment - ' = ' should be correct variable assignment
 * oelint.vars.specific - Variable is specific to an unknown identifier


### PR DESCRIPTION
Some special characters, as the dollar symbol and the curly brackets,
can cause formatting issues if not escaped. The text then becomes
similar to an italic style, and the special characters are not shown. I
had this behaviour when opening the README.md in Firefox and Chrome.