### PR TITLE
README: add reference to mfussenegger/nvim-lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,7 +376,7 @@ Find the extension in the [marketplace](https://marketplace.visualstudio.com/ite
 
 ## Vim / NeoVim integration
 
-Integration for Vim / NeoVim is provided by [ale](https://github.com/dense-analysis/ale).
+Integration for Vim / NeoVim is provided by [ale](https://github.com/dense-analysis/ale) or [nvim-lint](https://github.com/mfussenegger/nvim-lint).
 
 ## Jenkins integration
 


### PR DESCRIPTION
Support was added just today to [mfussenegger/nvim-lint](https://github.com/mfussenegger/nvim-lint).