### PR TITLE
Disable release workflow on forks

### DIFF
--- a/.github/workflows/autorelease.yml
+++ b/.github/workflows/autorelease.yml
@@ -20,6 +20,7 @@ jobs:
   release:
 
     runs-on: ubuntu-latest
+    if: github.repository == 'priv-kweihmann/oelint-adv'
 
     steps:
     - name: Checkout


### PR DESCRIPTION
Executes release workflow on mainline repository (= this one) only.

While the release wont hurt on forks, it'll fail always and there's not much benefit anyway.

------------------------------------------------

# Pull request checklist

## Bugfix

- [ ] A testcase was added to test the behavior

## New feature

- [ ] A testcase was added to test the behavior
- [ ] New functions are documented with docstrings
- [ ] No debug code is left
- [ ] README.md was updated to reflect the changes (check even if n.a.)
