### PR TITLE
listappend: except for FILESPATH

### DIFF
--- a/oelint_adv/rule_base/rule_vars_listappend.py
+++ b/oelint_adv/rule_base/rule_vars_listappend.py
@@ -18,7 +18,7 @@ class VarListAppend(Rule):
         for i in items:
             if not any(i.VarName.startswith(x) for x in needles):
                 continue
-            if i.VarName.startswith('FILESEXTRAPATHS'):
+            if any(i.VarName.startswith(x) for x in ['FILESEXTRAPATHS', 'FILESPATH']):
                 # Caught by the `FILES` above but this list is colon separated.
                 continue
             ops = i.AppendOperation()

--- a/tests/test_class_oelint_vars_listappend.py
+++ b/tests/test_class_oelint_vars_listappend.py
@@ -86,6 +86,14 @@ class TestClassOelintVarsListAppend(TestBaseClass):
                                       'oelint_adv_test.bb':
                                       'SRC_URI .= " file://abc"',
                                   },
+                                  {
+                                      'oelint_adv_test.bb':
+                                      'FILESPATH_prepend := "${THISDIR}/file:"',
+                                  },
+                                  {
+                                      'oelint_adv_test.bb':
+                                      'FILESEXTRAPATHS_prepend := "${THISDIR}/file:"',
+                                  },
                               ],
                               )
     def test_good(self, input_, id_, occurrence):


### PR DESCRIPTION
When using `devtool` to modify recipes, `FILESPATH` is added to bbappend. And `FILESPATH` makes a false alarm of oelint.vars.listappend because it uses a colon as a delimiter.

# Pull request checklist

## Bugfix

- [x] A testcase was added to test the behavior

## New feature

- [ ] A testcase was added to test the behavior
- [ ] New functions are documented with docstrings
- [ ] No debug code is left
- [ ] README.md was updated to reflect the changes (check even if n.a.)
