### PR TITLE
Add oelint.vars.srcurichecksum

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,4 +1,4 @@
 [bumpversion]
-current_version = 3.19.3
+current_version = 3.20.0
 commit = False
 tag = False

--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ Rules marked with **[S]** can have multiple sub-IDs
 * oelint.vars.spacesassignment - ' = ' should be correct variable assignment
 * oelint.vars.specific - Variable is specific to an unknown identifier
 * oelint.vars.srcuriappend - Use SRC_URI_append otherwise this will override weak defaults by inherit
+* oelint.vars.srcurichecksum - If SRC_URI has URLs pointing single file that is not from VCS, then checksusm is required
 * oelint.vars.srcuridomains - Recipe is pulling from different domains, this will likely cause issues
 * oelint.vars.srcurifile - First item of SRC_URI should not be a file:// fetcher, if multiple fetcher are used
 * oelint.vars.srcurigittag - 'tag' in SRC_URI-options leads to not-reproducible builds

--- a/oelint_adv/rule_base/rule_var_src_uri_checksum.py
+++ b/oelint_adv/rule_base/rule_var_src_uri_checksum.py
@@ -1,0 +1,73 @@
+from oelint_parser.cls_item import Variable
+from oelint_adv.cls_rule import Rule
+from oelint_parser.helper_files import get_scr_components
+from oelint_parser.parser import INLINE_BLOCK
+
+
+class VarSRCUriOptions(Rule):
+    def __init__(self):
+        super(VarSRCUriOptions, self).__init__(id="oelint.vars.srcurichecksum",
+                                               severity="error",
+                                               message="<FOO>")
+
+    def check(self, _file, stash):
+        res = []
+        items = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
+                                  attribute=Variable.ATTR_VAR, attributeValue="SRC_URI")
+        md5sum = []
+        sha256sum = []
+        res_candidate = []
+        for i in items:
+            if i.Flag.endswith("md5sum"):
+                if i.Flag == "md5sum":
+                    md5sum.append("")
+                else:
+                    md5sum.append(i.Flag.rsplit(".", 1)[0])
+            elif i.Flag.endswith("sha256sum"):
+                if i.Flag == "sha256sum":
+                    sha256sum.append("")
+                else:
+                    sha256sum.append(i.Flag.rsplit(".", 1)[0])
+            else:
+                lines = [y.strip('"') for y in i.get_items() if y]
+                for x in lines:
+                    if x == INLINE_BLOCK:
+                        continue
+                    _url = get_scr_components(x)
+                    if _url["scheme"] in ["http", "https", "ftp", "ftps", "sftp", "s3", "az"]:
+                        name = ""
+                        if "name" in _url["options"]:
+                            name = _url["options"]["name"]
+                        res_candidate.append((name, i.Origin, i.InFileLine + lines.index(x)))
+
+        res_candidate.sort(key=lambda tup: tup[0])
+
+        no_name_src_uri = False
+        for (name, filename, filelines) in res_candidate:
+            message = ""
+            if name == "":
+                if no_name_src_uri:
+                    message = "if SRC_URI have multiple URLs, each URL has checksum"
+                else:
+                    if "" not in md5sum:
+                        message = "SRC_URI[md5sum]"
+                    if "" not in sha256sum:
+                        if len(message) > 0:
+                            message += ", "
+                        message += "SRC_URI[sha256sum]"
+                    if len(message) > 0:
+                        message += " is(are) needed"
+                no_name_src_uri = True
+            else:
+                if name not in md5sum:
+                    message = "SRC_URI[%s.md5sum]" % name
+                if name not in sha256sum:
+                    if len(message) > 0:
+                      message += ", "
+                    message += "SRC_URI[%s.sha256sum]" % name
+                if len(message) > 0:
+                    message += " is(are) needed"
+            if len(message) > 0:
+                res += self.finding(filename, filelines, message)
+
+        return res

--- a/oelint_adv/rule_base/rule_var_src_uri_checksum.py
+++ b/oelint_adv/rule_base/rule_var_src_uri_checksum.py
@@ -4,11 +4,11 @@ from oelint_parser.helper_files import get_scr_components
 from oelint_parser.parser import INLINE_BLOCK
 
 
-class VarSRCUriOptions(Rule):
+class VarSRCUriChecksum(Rule):
     def __init__(self):
-        super(VarSRCUriOptions, self).__init__(id="oelint.vars.srcurichecksum",
-                                               severity="error",
-                                               message="<FOO>")
+        super().__init__(id='oelint.vars.srcurichecksum',
+                         severity='error',
+                         message='<FOO>')
 
     def check(self, _file, stash):
         res = []

--- a/oelint_adv/rule_base/rule_var_src_uri_checksum.py
+++ b/oelint_adv/rule_base/rule_var_src_uri_checksum.py
@@ -60,11 +60,11 @@ class VarSRCUriChecksum(Rule):
                 no_name_src_uri = True
             else:
                 if name not in md5sum:
-                    message = "SRC_URI[%s.md5sum]" % name
+                    message = "SRC_URI[{n}.md5sum]".format(n=name)
                 if name not in sha256sum:
                     if len(message) > 0:
-                      message += ", "
-                    message += "SRC_URI[%s.sha256sum]" % name
+                        message += ", "
+                    message += "SRC_URI[{n}.sha256sum]".format(n=name)
                 if len(message) > 0:
                     message += " is(are) needed"
             if len(message) > 0:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 anytree ~= 2.8
 colorama ~= 0.4
-oelint-parser ~= 2.9.4
+oelint-parser >= 2.9.4
 urllib3 ~= 1.26
 wheel ~= 0.38

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 anytree ~= 2.8
 colorama ~= 0.4
-oelint-parser ~= 2.9
+oelint-parser ~= 2.9.4
 urllib3 ~= 1.26
 wheel ~= 0.38

--- a/tests/test_class_oelint_vars_srcurichecksum.py
+++ b/tests/test_class_oelint_vars_srcurichecksum.py
@@ -1,0 +1,133 @@
+import pytest
+
+from .base import TestBaseClass
+
+
+class TestClassOelintVarsSRCURICHECKSUM(TestBaseClass):
+
+    @pytest.mark.parametrize('id', ['oelint.vars.srcurichecksum'])
+    @pytest.mark.parametrize('occurance', [1])
+    @pytest.mark.parametrize('input',
+        [
+            {
+                'oelint_adv_test.bb':
+                '''
+                SRC_URI += "ftp://foo;name=f3"
+                '''
+            },
+            {
+                'oelint_adv_test.bb':
+                '''
+                SRC_URI += "http://foo;name=f1"
+                SRC_URI[f1.md5sum] = "a"
+                '''
+            },
+            {
+                'oelint_adv_test.bb':
+                '''
+                SRC_URI += "https://foo;name=f2"
+                SRC_URI[f2.sha256sum] = "a"
+                '''
+            },
+            {
+                'oelint_adv_test.bb':
+                '''
+                SRC_URI += "ftp://foo"
+                SRC_URI += "ftp://foo"
+                SRC_URI += "http://foo;name=f1"
+                SRC_URI += "https://foo;name=f2"
+                SRC_URI[f1.md5sum] = "a"
+                SRC_URI[f1.sha256sum] = "a"
+                SRC_URI[f2.md5sum] = "a"
+                SRC_URI[f2.sha256sum] = "a"
+                SRC_URI[md5sum] = "a"
+                SRC_URI[sha256sum] = "a"
+                '''
+            },
+            {
+                'oelint_adv_test.bb':
+                '''
+                SRC_URI += "ftp://foo"
+                '''
+            },
+            {
+                'oelint_adv_test.bb':
+                '''
+                SRC_URI += "ftp://foo"
+                SRC_URI[sha256sum] = "a"
+                '''
+            },
+            {
+                'oelint_adv_test.bb':
+                '''
+                SRC_URI += "ftp://foo"
+                SRC_URI[md5sum] = "a"
+                '''
+            },
+        ],
+    )
+    def test_bad(self, input, id, occurance):
+        self.check_for_id(self._create_args(input), id, occurance)
+
+    @pytest.mark.parametrize('id', ['oelint.vars.srcurichecksum'])
+    @pytest.mark.parametrize('occurance', [0])
+    @pytest.mark.parametrize('input',
+        [
+            {
+                'oelint_adv_test.bb':
+                '''
+                SRC_URI += "file://foo"
+                SRC_URI += "bzr://foo"
+                SRC_URI += "crcc://foo"
+                SRC_URI += "cvs://foo"
+                SRC_URI += "ftp://foo;name=f3"
+                SRC_URI += "git://foo;name"
+                SRC_URI += "gitsm://foo"
+                SRC_URI += "gitannex://foo"
+                SRC_URI += "hg://foo"
+                SRC_URI += "http://foo;name=f1"
+                SRC_URI += "https://foo;name=f2"
+                SRC_URI += "osc://foo"
+                SRC_URI += "p4://foo"
+                SRC_URI += "repo://foo"
+                SRC_URI += "ssh://foo"
+                SRC_URI += "s3://foo;name=f5"
+                SRC_URI += "sftp://foo;name=f4"
+                SRC_URI += "npm://foo"
+                SRC_URI += "svn://foo"
+                SRC_URI += "az://foo;name=f6"
+                SRC_URI[f1.md5sum] = "a"
+                SRC_URI[f1.sha256sum] = "a"
+                SRC_URI[f2.md5sum] = "a"
+                SRC_URI[f2.sha256sum] = "a"
+                SRC_URI[f3.md5sum] = "a"
+                SRC_URI[f3.sha256sum] = "a"
+                SRC_URI[f4.md5sum] = "a"
+                SRC_URI[f4.sha256sum] = "a"
+                SRC_URI[f5.md5sum] = "a"
+                SRC_URI[f5.sha256sum] = "a"
+                SRC_URI[f6.md5sum] = "a"
+                SRC_URI[f6.sha256sum] = "a"
+                '''
+            },
+            {
+                'oelint_adv_test.bb':
+                '''
+                SRC_URI += "ftp://foo \\
+                            ftp://foo;name=f1"
+                SRC_URI[md5sum] = "a"
+                SRC_URI[sha256sum] = "a"
+                SRC_URI[f1.md5sum] = "a"
+                SRC_URI[f1.sha256sum] = "a"
+                '''
+            },
+            {
+                'oelint_adv_test.bb':
+                '''
+                SRC_URI += "${@["", "file://init.cfg"][(d.getVar(\'VIRTUAL-RUNTIME_init_manager\') == \'busybox\')]}"
+                '''
+            },
+        ],
+    )
+    def test_good(self, input, id, occurance):
+        self.check_for_id(self._create_args(input), id, occurance)

--- a/tests/test_class_oelint_vars_srcurichecksum.py
+++ b/tests/test_class_oelint_vars_srcurichecksum.py
@@ -1,133 +1,133 @@
-import pytest
+import pytest  # noqa: I900
 
 from .base import TestBaseClass
 
 
 class TestClassOelintVarsSRCURICHECKSUM(TestBaseClass):
 
-    @pytest.mark.parametrize('id', ['oelint.vars.srcurichecksum'])
-    @pytest.mark.parametrize('occurance', [1])
-    @pytest.mark.parametrize('input',
-        [
-            {
-                'oelint_adv_test.bb':
-                '''
-                SRC_URI += "ftp://foo;name=f3"
-                '''
-            },
-            {
-                'oelint_adv_test.bb':
-                '''
-                SRC_URI += "http://foo;name=f1"
-                SRC_URI[f1.md5sum] = "a"
-                '''
-            },
-            {
-                'oelint_adv_test.bb':
-                '''
-                SRC_URI += "https://foo;name=f2"
-                SRC_URI[f2.sha256sum] = "a"
-                '''
-            },
-            {
-                'oelint_adv_test.bb':
-                '''
-                SRC_URI += "ftp://foo"
-                SRC_URI += "ftp://foo"
-                SRC_URI += "http://foo;name=f1"
-                SRC_URI += "https://foo;name=f2"
-                SRC_URI[f1.md5sum] = "a"
-                SRC_URI[f1.sha256sum] = "a"
-                SRC_URI[f2.md5sum] = "a"
-                SRC_URI[f2.sha256sum] = "a"
-                SRC_URI[md5sum] = "a"
-                SRC_URI[sha256sum] = "a"
-                '''
-            },
-            {
-                'oelint_adv_test.bb':
-                '''
-                SRC_URI += "ftp://foo"
-                '''
-            },
-            {
-                'oelint_adv_test.bb':
-                '''
-                SRC_URI += "ftp://foo"
-                SRC_URI[sha256sum] = "a"
-                '''
-            },
-            {
-                'oelint_adv_test.bb':
-                '''
-                SRC_URI += "ftp://foo"
-                SRC_URI[md5sum] = "a"
-                '''
-            },
-        ],
-    )
-    def test_bad(self, input, id, occurrence):
-        self.check_for_id(self._create_args(input), id, occurrence)
+    @pytest.mark.parametrize('id_', ['oelint.vars.srcurichecksum'])
+    @pytest.mark.parametrize('occurrence', [1])
+    @pytest.mark.parametrize('input_',
+                             [
+                                 {
+                                     'oelint_adv_test.bb':
+                                     '''
+                                     SRC_URI += "ftp://foo;name=f3"
+                                     ''',
+                                 },
+                                 {
+                                     'oelint_adv_test.bb':
+                                     '''
+                                     SRC_URI += "http://foo;name=f1"
+                                     SRC_URI[f1.md5sum] = "a"
+                                     ''',
+                                 },
+                                 {
+                                     'oelint_adv_test.bb':
+                                     '''
+                                     SRC_URI += "https://foo;name=f2"
+                                     SRC_URI[f2.sha256sum] = "a"
+                                     ''',
+                                 },
+                                 {
+                                     'oelint_adv_test.bb':
+                                     '''
+                                     SRC_URI += "ftp://foo"
+                                     SRC_URI += "ftp://foo"
+                                     SRC_URI += "http://foo;name=f1"
+                                     SRC_URI += "https://foo;name=f2"
+                                     SRC_URI[f1.md5sum] = "a"
+                                     SRC_URI[f1.sha256sum] = "a"
+                                     SRC_URI[f2.md5sum] = "a"
+                                     SRC_URI[f2.sha256sum] = "a"
+                                     SRC_URI[md5sum] = "a"
+                                     SRC_URI[sha256sum] = "a"
+                                     ''',
+                                 },
+                                 {
+                                     'oelint_adv_test.bb':
+                                     '''
+                                     SRC_URI += "ftp://foo"
+                                     ''',
+                                 },
+                                 {
+                                     'oelint_adv_test.bb':
+                                     '''
+                                     SRC_URI += "ftp://foo"
+                                     SRC_URI[sha256sum] = "a"
+                                     ''',
+                                 },
+                                 {
+                                     'oelint_adv_test.bb':
+                                     '''
+                                     SRC_URI += "ftp://foo"
+                                     SRC_URI[md5sum] = "a"
+                                     ''',
+                                 },
+                             ],
+                             )
+    def test_bad(self, input_, id_, occurrence):
+        self.check_for_id(self._create_args(input_), id_, occurrence)
 
-    @pytest.mark.parametrize('id', ['oelint.vars.srcurichecksum'])
-    @pytest.mark.parametrize('occurance', [0])
-    @pytest.mark.parametrize('input',
-        [
-            {
-                'oelint_adv_test.bb':
-                '''
-                SRC_URI += "file://foo"
-                SRC_URI += "bzr://foo"
-                SRC_URI += "crcc://foo"
-                SRC_URI += "cvs://foo"
-                SRC_URI += "ftp://foo;name=f3"
-                SRC_URI += "git://foo;name"
-                SRC_URI += "gitsm://foo"
-                SRC_URI += "gitannex://foo"
-                SRC_URI += "hg://foo"
-                SRC_URI += "http://foo;name=f1"
-                SRC_URI += "https://foo;name=f2"
-                SRC_URI += "osc://foo"
-                SRC_URI += "p4://foo"
-                SRC_URI += "repo://foo"
-                SRC_URI += "ssh://foo"
-                SRC_URI += "s3://foo;name=f5"
-                SRC_URI += "sftp://foo;name=f4"
-                SRC_URI += "npm://foo"
-                SRC_URI += "svn://foo"
-                SRC_URI += "az://foo;name=f6"
-                SRC_URI[f1.md5sum] = "a"
-                SRC_URI[f1.sha256sum] = "a"
-                SRC_URI[f2.md5sum] = "a"
-                SRC_URI[f2.sha256sum] = "a"
-                SRC_URI[f3.md5sum] = "a"
-                SRC_URI[f3.sha256sum] = "a"
-                SRC_URI[f4.md5sum] = "a"
-                SRC_URI[f4.sha256sum] = "a"
-                SRC_URI[f5.md5sum] = "a"
-                SRC_URI[f5.sha256sum] = "a"
-                SRC_URI[f6.md5sum] = "a"
-                SRC_URI[f6.sha256sum] = "a"
-                '''
-            },
-            {
-                'oelint_adv_test.bb':
-                '''
-                SRC_URI += "ftp://foo \\
-                            ftp://foo;name=f1"
-                SRC_URI[md5sum] = "a"
-                SRC_URI[sha256sum] = "a"
-                SRC_URI[f1.md5sum] = "a"
-                SRC_URI[f1.sha256sum] = "a"
-                '''
-            },
-            {
-                'oelint_adv_test.bb':
-                '''
-                SRC_URI += "${@["", "file://init.cfg"][(d.getVar(\'VIRTUAL-RUNTIME_init_manager\') == \'busybox\')]}"
-                '''
-            },
-        ],
-    )
-    def test_good(self, input, id, occurrence):
-        self.check_for_id(self._create_args(input), id, occurrence)
+    @pytest.mark.parametrize('id_', ['oelint.vars.srcurichecksum'])
+    @pytest.mark.parametrize('occurrence', [0])
+    @pytest.mark.parametrize('input_',
+                             [
+                                 {
+                                     'oelint_adv_test.bb':
+                                     '''
+                                     SRC_URI += "file://foo"
+                                     SRC_URI += "bzr://foo"
+                                     SRC_URI += "crcc://foo"
+                                     SRC_URI += "cvs://foo"
+                                     SRC_URI += "ftp://foo;name=f3"
+                                     SRC_URI += "git://foo;name"
+                                     SRC_URI += "gitsm://foo"
+                                     SRC_URI += "gitannex://foo"
+                                     SRC_URI += "hg://foo"
+                                     SRC_URI += "http://foo;name=f1"
+                                     SRC_URI += "https://foo;name=f2"
+                                     SRC_URI += "osc://foo"
+                                     SRC_URI += "p4://foo"
+                                     SRC_URI += "repo://foo"
+                                     SRC_URI += "ssh://foo"
+                                     SRC_URI += "s3://foo;name=f5"
+                                     SRC_URI += "sftp://foo;name=f4"
+                                     SRC_URI += "npm://foo"
+                                     SRC_URI += "svn://foo"
+                                     SRC_URI += "az://foo;name=f6"
+                                     SRC_URI[f1.md5sum] = "a"
+                                     SRC_URI[f1.sha256sum] = "a"
+                                     SRC_URI[f2.md5sum] = "a"
+                                     SRC_URI[f2.sha256sum] = "a"
+                                     SRC_URI[f3.md5sum] = "a"
+                                     SRC_URI[f3.sha256sum] = "a"
+                                     SRC_URI[f4.md5sum] = "a"
+                                     SRC_URI[f4.sha256sum] = "a"
+                                     SRC_URI[f5.md5sum] = "a"
+                                     SRC_URI[f5.sha256sum] = "a"
+                                     SRC_URI[f6.md5sum] = "a"
+                                     SRC_URI[f6.sha256sum] = "a"
+                                     ''',
+                                 },
+                                 {
+                                     'oelint_adv_test.bb':
+                                     '''
+                                     SRC_URI += "ftp://foo \\
+                                                 ftp://foo;name=f1"
+                                     SRC_URI[md5sum] = "a"
+                                     SRC_URI[sha256sum] = "a"
+                                     SRC_URI[f1.md5sum] = "a"
+                                     SRC_URI[f1.sha256sum] = "a"
+                                     ''',
+                                 },
+                                 {
+                                     'oelint_adv_test.bb':
+                                     '''
+                                     SRC_URI += "${@["", "file://init.cfg"][(d.getVar(\'VIRTUAL-RUNTIME_init_manager\') == \'busybox\')]}"
+                                     ''',
+                                 },
+                             ],
+                             )
+    def test_good(self, input_, id_, occurrence):
+        self.check_for_id(self._create_args(input_), id_, occurrence)

--- a/tests/test_class_oelint_vars_srcurichecksum.py
+++ b/tests/test_class_oelint_vars_srcurichecksum.py
@@ -66,8 +66,8 @@ class TestClassOelintVarsSRCURICHECKSUM(TestBaseClass):
             },
         ],
     )
-    def test_bad(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_bad(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)
 
     @pytest.mark.parametrize('id', ['oelint.vars.srcurichecksum'])
     @pytest.mark.parametrize('occurance', [0])
@@ -129,5 +129,5 @@ class TestClassOelintVarsSRCURICHECKSUM(TestBaseClass):
             },
         ],
     )
-    def test_good(self, input, id, occurance):
-        self.check_for_id(self._create_args(input), id, occurance)
+    def test_good(self, input, id, occurrence):
+        self.check_for_id(self._create_args(input), id, occurrence)


### PR DESCRIPTION
If SRC_URI has URLs pointing single file that is not from VCS, then checksusm is required

refs:
https://docs.yoctoproject.org/4.1.1/dev-manual/common-tasks.html?highlight=md5sum#fetching-code

Below fetchers recommends checksum. (def recommends_checksum return True) https://github.com/openembedded/bitbake/blob/master/lib/bb/fetch2/wget.py (http, https, ftp, ftps) https://github.com/openembedded/bitbake/blob/master/lib/bb/fetch2/s3.py (s3) https://github.com/openembedded/bitbake/blob/master/lib/bb/fetch2/sftp.py (sftp) https://github.com/openembedded/bitbake/blob/master/lib/bb/fetch2/az.py (az) - inherit wget

# Pull request checklist

## Bugfix

- [ ] A testcase was added to test the behavior

## New feature

- [x] A testcase was added to test the behavior
- [ ] New functions are documented with docstrings
- [x] No debug code is left
- [x] README.md was updated to reflect the changes (check even if n.a.)
