### PR TITLE
Change `_` to `:` in README.md and messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Rules marked with **[S]** can have multiple sub-IDs
 * oelint.task.order - Order of tasks **[S]**
 * oelint.task.pythonprefix - Tasks containing python code should be prefixed with 'python' in function header
 * oelint.var.bbclassextend - Use BBCLASSEXTEND when possible
-* oelint.var.filesoverride - FILES_* variables should not be overridden
+* oelint.var.filesoverride - FILES:*(FILES_*) variables should not be overridden
 * oelint.var.improperinherit - Warn about improperly named inherits
 * oelint.var.licenseremotefile - License shall be a file in remote source not a local file
 * oelint.var.mandatoryvar - Check for mandatory variables **[S]**
@@ -160,7 +160,7 @@ Rules marked with **[S]** can have multiple sub-IDs
 * oelint.var.rootfspostcmd - ROOTFS_POSTPROCESS_COMMAND should not have trailing blanks
 * oelint.var.srcuriwildcard - 'SRC_URI' should not contain any wildcards
 * oelint.var.suggestedvar - Notice on suggested variables **[S]**
-* oelint.vars.appendop - Use '_append' instead of ' += '
+* oelint.vars.appendop - Use ':append(_append)' instead of ' += '
 * oelint.vars.autorev - The usage of 'AUTOREV' for SRCREV leads to not reproducible builds
 * oelint.vars.bbvars - Variables that shouldn't be altered in recipe scope **[S]**
 * oelint.vars.bugtrackerisurl - BUGTRACKER should be an URL
@@ -195,7 +195,7 @@ Rules marked with **[S]** can have multiple sub-IDs
 * oelint.vars.sectionlowercase - SECTION should be lowercase only **[F]**
 * oelint.vars.spacesassignment - ' = ' should be correct variable assignment
 * oelint.vars.specific - Variable is specific to an unknown identifier
-* oelint.vars.srcuriappend - Use SRC_URI_append otherwise this will override weak defaults by inherit
+* oelint.vars.srcuriappend - Use SRC_URI:append(SRC_URI_append) otherwise this will override weak defaults by inherit
 * oelint.vars.srcurichecksum - If SRC_URI has URLs pointing single file that is not from VCS, then checksusm is required
 * oelint.vars.srcuridomains - Recipe is pulling from different domains, this will likely cause issues
 * oelint.vars.srcurifile - First item of SRC_URI should not be a file:// fetcher, if multiple fetcher are used
@@ -366,7 +366,7 @@ Multiple IDs can be separated by commas.
 
 ```bitbake
 # nooelint: oelint.vars.insaneskip
-INSANE_SKIP_${PN} = "foo"
+INSANE_SKIP:${PN} = "foo"
 ```
 
 will not warn about the usage of `INSANE_SKIP`.

--- a/oelint_adv/rule_base/rule_var_appendop.py
+++ b/oelint_adv/rule_base/rule_var_appendop.py
@@ -18,18 +18,20 @@ class VarAppendOperation(Rule):
             _weak = [x for x in items if x.VarName == name and x.VarOp == ' ?= ']
             _items = [x for x in items if x.VarName == name and x not in _weakest + _weak and x.VarOp in [' .= ', ' += ']]
             for i in _items:
+                override_delimiter = i.OverrideDelimiter
                 if any(_weakest):
                     res += self.finding(i.Origin, i.InFileLine, override_msg=self.Msg.format(
-                        a='_append', b=i.VarOp, c=_weakest[0].Raw))
+                        a='{od}append'.format(od=override_delimiter), b=i.VarOp, c=_weakest[0].Raw))
                 elif any(x.Line > i.Line for x in _weak):
                     res += self.finding(i.Origin, i.InFileLine, override_msg=self.Msg.format(
-                        a='_append', b=i.VarOp, c=_weak[0].Raw))
+                        a='{od}append'.format(od=override_delimiter), b=i.VarOp, c=_weak[0].Raw))
             _items = [x for x in items if x.VarName == name and x not in _weakest + _weak and x.VarOp in [' =. ', ' =+ ']]
             for i in _items:
+                override_delimiter = i.OverrideDelimiter
                 if any(_weakest):
                     res += self.finding(i.Origin, i.InFileLine, override_msg=self.Msg.format(
-                        a='_prepend', b=i.VarOp, c=_weakest[0].Raw))
+                        a='{od}prepend'.format(od=override_delimiter), b=i.VarOp, c=_weakest[0].Raw))
                 elif any(x.Line > i.Line for x in _weak):
                     res += self.finding(i.Origin, i.InFileLine, override_msg=self.Msg.format(
-                        a='_prepend', b=i.VarOp, c=_weak[0].Raw))
+                        a='{od}prepend'.format(od=override_delimiter), b=i.VarOp, c=_weak[0].Raw))
         return res

--- a/oelint_adv/rule_base/rule_var_filesextrapaths.py
+++ b/oelint_adv/rule_base/rule_var_filesextrapaths.py
@@ -15,7 +15,7 @@ class VarBugtrackerIsUrl(Rule):
         items = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
                                   attribute=Variable.ATTR_VAR)
         for i in items:
-            if i.VarName in ['FILESEXTRAPATHS_prepend', 'FILESEXTRAPATHS_append', 'FILESEXTRAPATHS']:
+            if i.VarName in ['FILESEXTRAPATHS']:
                 _, ext = os.path.splitext(i.Origin)
                 if ext == '.bb':
                     res += self.finding(i.Origin, i.InFileLine)

--- a/oelint_adv/rule_base/rule_var_filesextrapathsop.py
+++ b/oelint_adv/rule_base/rule_var_filesextrapathsop.py
@@ -13,7 +13,7 @@ class VarBugtrackerIsUrl(Rule):
         items = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
                                   attribute=Variable.ATTR_VAR)
         for i in items:
-            if i.VarName in ['FILESEXTRAPATHS_prepend', 'FILESEXTRAPATHS_append', 'FILESEXTRAPATHS']:
+            if i.VarName in ['FILESEXTRAPATHS']:
                 if i.VarOp != ' := ':
                     res += self.finding(i.Origin, i.InFileLine)
         return res

--- a/oelint_adv/rule_base/rule_var_inconsspaces.py
+++ b/oelint_adv/rule_base/rule_var_inconsspaces.py
@@ -24,6 +24,8 @@ class VarInconSpaces(Rule):
                 res += self.finding(i.Origin, i.InFileLine,
                                     'Assignment should be \'VAR += "foo"\' not \'VAR += " foo"\'')
             if 'append' in app_operation and not _stripped.startswith(' '):
+                override_delimiter = i.OverrideDelimiter
                 res += self.finding(i.Origin, i.InFileLine,
-                                    'Assignment should be \'VAR_append = " foo"\' not \'VAR_append = "foo"\'')
+                                    'Assignment should be \'VAR{od}append = " foo"\' not \'VAR{od}append = "foo"\''.format(
+                                        od=override_delimiter))
         return res

--- a/oelint_adv/rule_base/rule_var_insaneskip.py
+++ b/oelint_adv/rule_base/rule_var_insaneskip.py
@@ -12,6 +12,6 @@ class VarInsaneSkip(Rule):
         res = []
         items = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
                                   attribute=Variable.ATTR_VAR)
-        for i in [x for x in items if x.VarName.startswith('INSANE_SKIP_') or x.VarName == 'INSANE_SKIP']:
+        for i in [x for x in items if x.VarName == 'INSANE_SKIP']:
             res += self.finding(i.Origin, i.InFileLine)
         return res

--- a/oelint_adv/rule_base/rule_var_src_uri_append.py
+++ b/oelint_adv/rule_base/rule_var_src_uri_append.py
@@ -6,7 +6,7 @@ class VarSRCUriGitTag(Rule):
     def __init__(self):
         super().__init__(id='oelint.vars.srcuriappend',
                          severity='error',
-                         message='Use SRC_URI_append otherwise this will override weak defaults by inherit')
+                         message='<FOO>')
 
     def check(self, _file, stash):
         res = []
@@ -22,5 +22,8 @@ class VarSRCUriGitTag(Rule):
                 # These are just the hashes
                 continue
             if item.VarOp in [' += ']:
-                res += self.finding(item.Origin, item.InFileLine)
+                override_delimiter = item.OverrideDelimiter
+                res += self.finding(item.Origin, item.InFileLine,
+                                    'Use SRC_URI{od}append otherwise this will override weak defaults by inherit'.format(
+                                        od=override_delimiter))
         return res

--- a/tests/test_class_oelint_var_filesoverride.py
+++ b/tests/test_class_oelint_var_filesoverride.py
@@ -25,6 +25,22 @@ class TestClassOelintVarFilesOverride(TestBaseClass):
                                      'oelint_adv_test.bb':
                                      'FILES_${PN}-dev := "foo"',
                                  },
+                                 {
+                                     'oelint_adv_test.bb':
+                                     'FILES:${PN} = " foo"',
+                                 },
+                                 {
+                                     'oelint_adv_test.bb':
+                                     'FILES:${PN} := "foo"',
+                                 },
+                                 {
+                                     'oelint_adv_test.bb':
+                                     'FILES:${PN}-dev = "foo"',
+                                 },
+                                 {
+                                     'oelint_adv_test.bb':
+                                     'FILES:${PN}-dev := "foo"',
+                                 },
                              ],
                              )
     def test_bad(self, input_, id_, occurrence):
@@ -77,6 +93,50 @@ class TestClassOelintVarFilesOverride(TestBaseClass):
                                  {
                                      'oelint_adv_test.bbappend':
                                      'FILES_${PN}-dev =. "foo "',
+                                 },
+                                 {
+                                     'oelint_adv_test.bbappend':
+                                     'FILES:SOLIBSDEV = "abc"',
+                                 },
+                                 {
+                                     'oelint_adv_test.bbappend':
+                                     'FILES:${PN}:append = " foo"',
+                                 },
+                                 {
+                                     'oelint_adv_test.bbappend':
+                                     'FILES:${PN}:prepend = "foo "',
+                                 },
+                                 {
+                                     'oelint_adv_test.bbappend':
+                                     'FILES:${PN} += "foo"',
+                                 },
+                                 {
+                                     'oelint_adv_test.bbappend':
+                                     'FILES:${PN} =+ "foo"',
+                                 },
+                                 {
+                                     'oelint_adv_test.bbappend':
+                                     'FILES:${PN} .= " foo"',
+                                 },
+                                 {
+                                     'oelint_adv_test.bbappend':
+                                     'FILES:${PN} =. "foo "',
+                                 },
+                                 {
+                                     'oelint_adv_test.bbappend':
+                                     'FILES:${PN}-dev += "foo"',
+                                 },
+                                 {
+                                     'oelint_adv_test.bbappend':
+                                     'FILES:${PN}-dev =+ "foo"',
+                                 },
+                                 {
+                                     'oelint_adv_test.bbappend':
+                                     'FILES:${PN}-dev .= " foo"',
+                                 },
+                                 {
+                                     'oelint_adv_test.bbappend':
+                                     'FILES:${PN}-dev =. "foo "',
                                  },
                              ],
                              )

--- a/tests/test_class_oelint_vars_appendop.py
+++ b/tests/test_class_oelint_vars_appendop.py
@@ -130,6 +130,62 @@ class TestClassOelintVarAppendOp(TestBaseClass):
                                      I ?= "1"
                                      ''',
                                  },
+                                 {
+                                     'oelint_adv_test.bb':
+                                     '''
+                                     A ??= "1"
+                                     A:append = "2"
+                                     ''',
+                                 },
+                                 {
+                                     'oelint_adv_test.bb':
+                                     '''
+                                     B:append = "B"
+                                     B ?= "A"
+                                     ''',
+                                 },
+                                 {
+                                     'oelint_adv_test.bb':
+                                     '''
+                                     C ??= "1"
+                                     C:append = "2"
+                                     ''',
+                                 },
+                                 {
+                                     'oelint_adv_test.bb':
+                                     '''
+                                     D:append = "2"
+                                     D ?= "1"
+                                     ''',
+                                 },
+                                 {
+                                     'oelint_adv_test.bb':
+                                     '''
+                                     F ??= "1"
+                                     F:prepend = "2"
+                                     ''',
+                                 },
+                                 {
+                                     'oelint_adv_test.bb':
+                                     '''
+                                     G:prepend = "B"
+                                     G ?= "A"
+                                     ''',
+                                 },
+                                 {
+                                     'oelint_adv_test.bb':
+                                     '''
+                                     H ??= "1"
+                                     H:prepend = "2"
+                                     ''',
+                                 },
+                                 {
+                                     'oelint_adv_test.bb':
+                                     '''
+                                     I:prepend = "2"
+                                     I ?= "1"
+                                     ''',
+                                 },
                              ],
                              )
     def test_good(self, input_, id_, occurrence):

--- a/tests/test_class_oelint_vars_fileextrapaths.py
+++ b/tests/test_class_oelint_vars_fileextrapaths.py
@@ -19,6 +19,14 @@ class TestClassOelintVarsFilextrapaths(TestBaseClass):
                                  },
                                  {
                                      'oelint_adv_test.bb':
+                                     'FILESEXTRAPATHS:prepend := "${THISDIR}/file"',
+                                 },
+                                 {
+                                     'oelint_adv_test.bb':
+                                     'FILESEXTRAPATHS:append := "${THISDIR}/file"',
+                                 },
+                                 {
+                                     'oelint_adv_test.bb':
                                      'FILESEXTRAPATHS += "${THISDIR}/file"',
                                  },
                              ],
@@ -37,6 +45,14 @@ class TestClassOelintVarsFilextrapaths(TestBaseClass):
                                  {
                                      'oelint_adv_test.bbappend':
                                      'FILESEXTRAPATHS_append := "${THISDIR}/file"',
+                                 },
+                                 {
+                                     'oelint_adv_test.bbappend':
+                                     'FILESEXTRAPATHS:prepend := "${THISDIR}/file"',
+                                 },
+                                 {
+                                     'oelint_adv_test.bbappend':
+                                     'FILESEXTRAPATHS:append := "${THISDIR}/file"',
                                  },
                              ],
                              )

--- a/tests/test_class_oelint_vars_fileextrapathsop.py
+++ b/tests/test_class_oelint_vars_fileextrapathsop.py
@@ -19,6 +19,14 @@ class TestClassOelintVarsFilextrapaths(TestBaseClass):
                                  },
                                  {
                                      'oelint_adv_test.bb':
+                                     'FILESEXTRAPATHS:prepend .= "${THISDIR}/file"',
+                                 },
+                                 {
+                                     'oelint_adv_test.bb':
+                                     'FILESEXTRAPATHS:append = "${THISDIR}/file"',
+                                 },
+                                 {
+                                     'oelint_adv_test.bb':
                                      'FILESEXTRAPATHS += "${THISDIR}/file"',
                                  },
                                  {
@@ -49,6 +57,14 @@ class TestClassOelintVarsFilextrapaths(TestBaseClass):
                                  {
                                      'oelint_adv_test.bbappend':
                                      'FILESEXTRAPATHS_append := "${THISDIR}/file"',
+                                 },
+                                 {
+                                     'oelint_adv_test.bbappend':
+                                     'FILESEXTRAPATHS:prepend := "${THISDIR}/file"',
+                                 },
+                                 {
+                                     'oelint_adv_test.bbappend':
+                                     'FILESEXTRAPATHS:append := "${THISDIR}/file"',
                                  },
                                  {
                                      'oelint_adv_test.bbappend':

--- a/tests/test_class_oelint_vars_inconspaces.py
+++ b/tests/test_class_oelint_vars_inconspaces.py
@@ -19,6 +19,10 @@ class TestClassOelintVarsInconSpaces(TestBaseClass):
                                  },
                                  {
                                      'oelint_adv_test.bb':
+                                     'VAR:append = "fhhh"',
+                                 },
+                                 {
+                                     'oelint_adv_test.bb':
                                      '''
                                      RDEPENDS:${PN}-ptest:append:libc-glibc = "\\
                                      locale-base-en-us.iso-8859-1 \\
@@ -45,6 +49,14 @@ class TestClassOelintVarsInconSpaces(TestBaseClass):
                                  {
                                      'oelint_adv_test.bb':
                                      'FILESEXTRAPATHS_append := "foo:"',
+                                 },
+                                 {
+                                     'oelint_adv_test.bb':
+                                     'VAR:append = " fhhh"',
+                                 },
+                                 {
+                                     'oelint_adv_test.bb':
+                                     'FILESEXTRAPATHS:append := "foo:"',
                                  },
                                  {
                                      'oelint_adv_test.bb':

--- a/tests/test_class_oelint_vars_insaneskip.py
+++ b/tests/test_class_oelint_vars_insaneskip.py
@@ -21,6 +21,19 @@ class TestClassOelintVarsInsaneSkip(TestBaseClass):
                                      'oelint_adv_test.bb':
                                      'INSANE_SKIP_bla_class-native = "a"',
                                  },
+                                 {
+                                     'oelint_adv_test.bb':
+                                     'INSANE_SKIP:${PN} = "a"',
+                                 },
+                                 {
+                                     'oelint_adv_test.bb':
+                                     'INSANE_SKIP:bla = "a"',
+                                 },
+                                 {
+                                     'oelint_adv_test.bb':
+                                     'INSANE_SKIP:bla:class-native = "a"',
+                                 },
+
                              ],
                              )
     def test_bad(self, input_, id_, occurrence):

--- a/tests/test_class_oelint_vars_srcuriappend.py
+++ b/tests/test_class_oelint_vars_srcuriappend.py
@@ -46,6 +46,20 @@ class TestClassOelintVarsSRCURIappend(TestBaseClass):
                                  {
                                      'oelint_adv_test.bb':
                                      '''
+                                     SRC_URI:append = " file://abc"
+                                     inherit abc
+                                     ''',
+                                 },
+                                 {
+                                     'oelint_adv_test.bb':
+                                     '''
+                                     SRC_URI:remove = "file://abc"
+                                     inherit abc
+                                     ''',
+                                 },
+                                 {
+                                     'oelint_adv_test.bb':
+                                     '''
                                      SRC_URI_prepend = "file://abc "
                                      inherit abc
                                      ''',


### PR DESCRIPTION
In honister release, override syntax was changed.
However, messages and README.md are still written with the old override syntax.

Refs: https://docs.yoctoproject.org/migration-guides/migration-3.4.html#override-syntax-changes

This commit doesn't affect code behavior.

# Pull request checklist

## Bugfix

- [x] A testcase was added to test the behavior

## New feature

- [ ] A testcase was added to test the behavior
- [ ] New functions are documented with docstrings
- [ ] No debug code is left
- [ ] README.md was updated to reflect the changes (check even if n.a.)
