### PR TITLE
listappend: refactor code

### DIFF
--- a/oelint_adv/rule_base/rule_vars_listappend.py
+++ b/oelint_adv/rule_base/rule_vars_listappend.py
@@ -18,7 +18,7 @@ class VarListAppend(Rule):
         for i in items:
             if not any(i.VarName.startswith(x) for x in needles):
                 continue
-            if any(i.VarName.startswith(x) for x in ['FILESEXTRAPATHS', 'FILESPATH']):
+            if i.VarName.startswith(('FILESEXTRAPATHS', 'FILESPATH')):
                 # Caught by the `FILES` above but this list is colon separated.
                 continue
             ops = i.AppendOperation()


### PR DESCRIPTION
`startswith` of String can also receive a tuple as an argument.

# Pull request checklist

## Bugfix

- [ ] A testcase was added to test the behavior

## New feature

- [ ] A testcase was added to test the behavior
- [ ] New functions are documented with docstrings
- [ ] No debug code is left
- [ ] README.md was updated to reflect the changes (check even if n.a.)
