### PR TITLE
dependsordered: ignore append and prepend ops

### DIFF
--- a/oelint_adv/rule_base/rule_var_depends_ordered.py
+++ b/oelint_adv/rule_base/rule_var_depends_ordered.py
@@ -16,12 +16,23 @@ class VarDependsOrdered(Rule):
         res.update(f.GetClassOverride() for f in findings)
         return res
 
+    def is_applicable(self, item):
+        if 'remove' in item.SubItems:
+            return False
+        if 'append' in item.SubItems:
+            return False
+        if 'prepend' in item.SubItems:
+            return False
+        if item.Origin.endswith('.bbclass'):
+            return False
+        return True
+
     def check(self, _file, stash):
         res = []
         items = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
                                   attribute=Variable.ATTR_VAR)
         # ignore the settings from bbclasses
-        items = [x for x in items if not x.Origin.endswith('.bbclass') and 'remove' not in x.SubItems]
+        items = [x for x in items if self.is_applicable(x)]
         _keys = {x.VarName for x in items if RegexRpl.match(
             r'DEPENDS|RDEPENDS', x.VarName)}
         _filegroups = {x.Origin for x in items}

--- a/tests/test_class_oelint_vars_dependsordered.py
+++ b/tests/test_class_oelint_vars_dependsordered.py
@@ -129,6 +129,20 @@ class TestClassOelintVarsDependsOrdered(TestBaseClass):
                                      RDEPENDS:${PN}:remove = "def"
                                      ''',
                                  },
+                                 {
+                                     'oelint_adv_test.bb':
+                                     '''
+                                     RDEPENDS:${PN} = "x y z"
+                                     RDEPENDS:${PN}:append:magic-machine = " a"
+                                     ''',
+                                 },
+                                 {
+                                     'oelint_adv_test.bb':
+                                     '''
+                                     RDEPENDS:${PN} = "x y z"
+                                     RDEPENDS:${PN}:prepend:magic-machine = "a "
+                                     ''',
+                                 },
                              ],
                              )
     def test_good(self, input_, id_, occurrence):


### PR DESCRIPTION
as by the nature of these operations ordering will be not possible anyway

Closes #357 

Signed-off-by: Konrad Weihmann <kweihmann@outlook.com>

# Pull request checklist

## Bugfix

- [x] A testcase was added to test the behavior

## New feature

- [ ] A testcase was added to test the behavior
- [ ] New functions are documented with docstrings
- [ ] No debug code is left
- [ ] README.md was updated to reflect the changes (check even if n.a.)
