### PR TITLE
Update list options to be usable in config file

### DIFF
--- a/oelint_adv/__main__.py
+++ b/oelint_adv/__main__.py
@@ -158,8 +158,10 @@ def arguments_post(args):  # noqa: C901 - complexity is still okay
 
     # Convert list symbols
     for _option in [
-        'suppress',
+        'addrules',
         'constantmods',
+        'customrules',
+        'suppress',
     ]:
         try:
             if not isinstance(getattr(args, _option), list):

--- a/tests/test_configfile.py
+++ b/tests/test_configfile.py
@@ -119,8 +119,6 @@ class TestConfigFile(TestBaseClass):
         # Test if the following options remain untouched
         for _option in [
             'output',
-            'addrules',
-            'customrules',
             'messageformat',
         ]:
             _cstfile = self._create_tempfile(
@@ -141,7 +139,9 @@ class TestConfigFile(TestBaseClass):
     def test_config_file_multiple(self, input_):
         # Test if the following options are converted to lists
         for _option in [
-            'suppress'
+            'addrules',
+            'customrules',
+            'suppress',
         ]:
             _cstfile = self._create_tempfile(
                 '.oelint.cfg', '[oelint]\n{item}=\t+True\n\t-False'.format(item=_option))


### PR DESCRIPTION
# Pull request checklist

## Bugfix

- [x] A testcase was added to test the behavior

## New feature

- [ ] A testcase was added to test the behavior
- [ ] New functions are documented with docstrings
- [ ] No debug code is left
- [ ] README.md was updated to reflect the changes (check even if n.a.)

Add option keys `customrules` and `addrules` to convert list symbols. 
Otherwise, these options are handled as strings when added via configuration file 
This causes that the iterations in `load_rules` will be done for each character on these variables and then ignored.