### PR TITLE
Run autorelease for mainline repo only

### DIFF
--- a/.github/workflows/autorelease.yml
+++ b/.github/workflows/autorelease.yml
@@ -29,6 +29,8 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    if: github.repository == 'priv-kweihmann/oelint-adv'
+
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -81,19 +83,19 @@ jobs:
         else
           echo DO_RELEASE=false >> $GITHUB_OUTPUT
         fi
-    
+
     - name: Install dependencies
       if: steps.release-needed.outputs.DO_RELEASE == 'true'
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-    
+
     - name: Bump version
       id: version-bump
       run: |
         pip install -r requirements-dev.txt
         bump2version --list ${{ steps.release-needed.outputs.RELEASE_TYPE }} ${{ env.VERSION_FILE }} >> $GITHUB_OUTPUT
-      
+
     - name: Build
       if: steps.release-needed.outputs.DO_RELEASE == 'true'
       run: |
@@ -112,7 +114,7 @@ jobs:
         tag: ${{ steps.version-bump.outputs.new_version }}
         generateReleaseNotes: true
         token: ${{ secrets.TOKEN }}
-  
+
     - name: Publish package
       if: steps.release-needed.outputs.DO_RELEASE == 'true' && env.PYPI_PUBLISH == '1'
       uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Limits the *autorelease* workflow to this repository only. It fails on forks and shouldn't run there anyway (I guess).


# Pull request checklist

## Bugfix

- [ ] A testcase was added to test the behavior

## New feature

- [ ] A testcase was added to test the behavior
- [ ] New functions are documented with docstrings
- [ ] No debug code is left
- [ ] README.md was updated to reflect the changes (check even if n.a.)
