### PR TITLE
#nooelint does not accept rules with underscores.

### DIFF
--- a/oelint_adv/__main__.py
+++ b/oelint_adv/__main__.py
@@ -295,7 +295,7 @@ def group_run(group, quiet, fix, jobs, rules, nobackup):
     for item in stash.GetItemsFor(classifier=Comment.CLASSIFIER):
         for line in item.get_items():
             m = re.match(
-                r'^#\s+nooelint:\s+(?P<ids>[A-Za-z0-9\.,]*)', line)
+                r'^#\s+nooelint:\s+(?P<ids>[A-Za-z0-9\.,_]*)', line)
             if m:
                 if item.Origin not in inline_supp_map:  # pragma: no cover
                     inline_supp_map[item.Origin] = {}


### PR DESCRIPTION
# Pull request checklist

Rules with '_' (underscore) in it can not be disabled via `#nooelint` (E.g. `oelint.var.suggestedvar.CVE_PRODUCT`)

Due to the regex used to identify `#nooelint` in the comment section, only rules without `underscore` can be disabled via inline comment.

## Bugfix

- [ ] A testcase was added to test the behavior

If a test case is needed just let me know and I will try to come up with a testcase