### PR TITLE
Wrong line number behind 'inherit' or 'require' for oelint.spaces.lineend

### DIFF
--- a/oelint_adv/rule_base/rule_nospace_line_end.py
+++ b/oelint_adv/rule_base/rule_nospace_line_end.py
@@ -15,7 +15,7 @@ class NoSpaceTrailingRule(Rule):
             _linecnt = 0
             for line in i.Raw.split('\n'):
                 if line.endswith(' '):
-                    res.append((i, i.Line + _linecnt))
+                    res.append((i, i.InFileLine + _linecnt))
                 _linecnt += 1
         return res
 


### PR DESCRIPTION
# Pull request checklist

If a `oelint.spaces.lineend` is find behind a `require` or `inherit` command, which `oelint-adv` can resolve, the line numbers for the `oelint.spaces.lineend` are wrongly calculated. The line number of the resulting file (with the content of the `inherit` or `require` file) is used for the finding generation.

## Bugfix

- [ ] A testcase was added to test the behavior

Due to the complicated nature of the finding I didn't find any test case. 😞 