### PR TITLE
Fix oelint.var.override false positive finding

### DIFF
--- a/oelint_adv/rule_base/rule_vars_variable_override.py
+++ b/oelint_adv/rule_base/rule_vars_variable_override.py
@@ -26,7 +26,7 @@ class VarOverride(Rule):
                 # as these will be handled during parse time
                 # and apply to different rules
                 _items = [x for x in items if x.SubItem == sub and not x.IsAppend(
-                ) and x.VarOp not in [' := ', ' ?= ', ' ??= '] and not x.Flag]
+                ) and x.VarOp.strip() not in [':=', '?=', '??='] and not x.Flag]
                 if len(_items) > 1:
                     _files = {os.path.basename(x.Origin) for x in _items}
                     res += self.finding(_items[0].Origin, _items[0].InFileLine,

--- a/tests/test_class_oelint_var_override.py
+++ b/tests/test_class_oelint_var_override.py
@@ -89,6 +89,27 @@ class TestClassOelintVarOverride(TestBaseClass):
                                      FILESEXTRAPATH_append := ":b"
                                      ''',
                                  },
+                                 {
+                                     'oelint_adv_test.bb':
+                                     '''
+                                     A = "2"
+                                     A  ?= "1"
+                                     '''
+                                 },
+                                 {
+                                     'oelint_adv_test.bb':
+                                     '''
+                                     A = "2"
+                                     A  ??= "1"
+                                     '''
+                                 },
+                                 {
+                                     'oelint_adv_test.bb':
+                                     '''
+                                     A = "2"
+                                     A  := "1"
+                                     '''
+                                 },
                              ],
                              )
     def test_good(self, input_, id_, occurrence):

--- a/tests/test_class_oelint_var_override.py
+++ b/tests/test_class_oelint_var_override.py
@@ -94,21 +94,21 @@ class TestClassOelintVarOverride(TestBaseClass):
                                      '''
                                      A = "2"
                                      A  ?= "1"
-                                     '''
+                                     ''',
                                  },
                                  {
                                      'oelint_adv_test.bb':
                                      '''
                                      A = "2"
                                      A  ??= "1"
-                                     '''
+                                     ''',
                                  },
                                  {
                                      'oelint_adv_test.bb':
                                      '''
                                      A = "2"
                                      A  := "1"
-                                     '''
+                                     ''',
                                  },
                              ],
                              )


### PR DESCRIPTION
# Pull request checklist

There might be a more widespread problem regarding the VarOp property handling.

## Bugfix

- [X] A testcase was added to test the behavior

