### PR TITLE
main: fix list assembly of suppress

### DIFF
--- a/oelint_adv/__main__.py
+++ b/oelint_adv/__main__.py
@@ -37,11 +37,11 @@ sys.path.append(os.path.abspath(os.path.join(__file__, '..')))
 class TypeSafeAppendAction(argparse.Action):
 
     def __call__(self, parser, namespace, values, option_string=None):
+        if not isinstance(values, str):
+            return  # pragma: no cover
         items = getattr(namespace, self.dest) or []
-        if isinstance(items, str):
-            items = RegexRpl.split(r'\s+|\t+|\n+', items)  # pragma: no cover
-        items.append(values)  # pragma: no cover
-        setattr(namespace, self.dest, items)  # pragma: no cover
+        items.extend(RegexRpl.split(r'\s+|\t+|\n+', values.strip('"').strip("'")))
+        setattr(namespace, self.dest, items)
 
 
 def deserialize_boolean_options(options: Dict) -> Dict[str, Union[str, bool]]:

--- a/tests/test_user_interface.py
+++ b/tests/test_user_interface.py
@@ -836,3 +836,22 @@ class TestClassIntegration(TestBaseClass):
         issues = [x[0] for x in run(_args)]
 
         assert sorted(issues, key=lambda x: x[0]) == issues
+
+    @pytest.mark.parametrize('input_',
+                             [
+                                 {
+                                     'oelint_adv-test_2.bb':
+                                     '''
+                                     VAR = "1"
+                                     INSANE_SKIP_${PN} = "foo"
+                                     ''',
+                                 }
+                             ],
+                             )
+    def test_suppress(self, capsys, input_):
+        _args = self._create_args(input_, ['--suppress="a b c"', '--suppress="d"'])
+
+        assert "a" in _args.suppress
+        assert "b" in _args.suppress
+        assert "c" in _args.suppress
+        assert "d" in _args.suppress


### PR DESCRIPTION
when passing `--suppress=a --suppress=b` into
the argparse instance, we would have gotten
weird results.
Fix that and also fully support having multiple
suppression as a space separated list passed
to the parser.
To avoid future regressions a test was added.

Co-authored-by: Angelo Compagnucci angelo.compagnucci@gmail.com

# Pull request checklist

## Bugfix

- [x] A testcase was added to test the behavior

## New feature

- [ ] A testcase was added to test the behavior
- [ ] New functions are documented with docstrings
- [ ] No debug code is left
- [ ] README.md was updated to reflect the changes (check even if n.a.)
