### PR TITLE
rulefile: enabled use of subids only

### DIFF
--- a/oelint_adv/__main__.py
+++ b/oelint_adv/__main__.py
@@ -341,7 +341,7 @@ def run(args):
 
         def rule_applicable(rule):
             if isinstance(rule, Rule):
-                res = not _rule_file or rule.ID in _rule_file
+                res = not _rule_file or any(x in _rule_file for x in rule.get_ids())  # pragma: no cover
                 res &= rule.ID not in get_suppressions()
             else:
                 res = not _rule_file or rule in _rule_file

--- a/tests/test_user_interface.py
+++ b/tests/test_user_interface.py
@@ -650,6 +650,34 @@ class TestClassIntegration(TestBaseClass):
         assert(any(issues))
 
     @pytest.mark.parametrize('input_',
+                            [
+                                {
+                                    'oelint adv-test.bb':
+                                    '''
+                                    A = "1"
+                                    ''',
+                                },
+                            ],
+                            )
+    def test_rulefile_subids_only(self, input_):
+        # local imports only
+        from oelint_adv.__main__ import run
+
+        _rule_file = {
+            "oelint.var.mandatoryvar.DESCRIPTION": "error",
+            "oelint.var.mandatoryvar.LICENSE": "error",
+            "oelint.var.mandatoryvar.SRC_URI": "error"
+        }
+
+        _cstfile = self._create_tempfile('rules.json', json.dumps(_rule_file))
+
+        _args = self._create_args(
+            input_, extraopts=['--rulefile={file}'.format(file=_cstfile)])
+        issues = [x[1] for x in run(_args)]
+        assert(not any(any(x.startswith(y) for y in _rule_file.keys()) for x in issues))
+
+
+    @pytest.mark.parametrize('input_',
                              [
                                  {
                                      'oelint adv-test.bb':
@@ -687,7 +715,7 @@ class TestClassIntegration(TestBaseClass):
         _args = self._create_args(
             input_, extraopts=['--rulefile={file}'.format(file=_cstfile)])
         issues = [x[1] for x in run(_args)]
-        assert(not any(issues))
+        assert(not any("oelint.var.mandatoryvar.DESCRIPTION" in x for x in issues))
 
     @pytest.mark.parametrize('input_',
                              [


### PR DESCRIPTION
In the latest rework an issues slipped in that
allowed only entire groups (or ID) to be
enabled/disabled, mind the subIDs as well when
loading the rules.
As they are filtered out afterwards it should be fine. This applies of course only to the rule itself,
thus we don't run into conflicts with the fix method call

Closes #436

# Pull request checklist

## Bugfix

- [x] A testcase was added to test the behavior

## New feature

- [ ] A testcase was added to test the behavior
- [ ] New functions are documented with docstrings
- [ ] No debug code is left
- [ ] README.md was updated to reflect the changes (check even if n.a.)
