### PR TITLE
misspell-rule: also use named resources

### DIFF
--- a/tests/test_class_oelint_vars_misspell.py
+++ b/tests/test_class_oelint_vars_misspell.py
@@ -58,6 +58,17 @@ class TestClassOelintVarsMispell(TestBaseClass):
                                      INITSCRIPT_PARAMS_${PN}-foo = "bar"
                                      ''',
                                  },
+                                 {
+                                     'oelint_adv_test.bb':
+                                     '''
+                                     FOO:qemux86 = "1"
+
+                                     SRC_URI = "git://github.com/znc/znc.git;name=znc;branch=master;protocol=https \\
+                                                git://github.com/jimloco/Csocket.git;destsuffix=git/third_party/Csocket;name=Csocket;branch=master;protocol=https"
+                                     SRCREV_znc = "bf253640d33d03331310778e001fb6f5aba2989e"
+                                     SRCREV_Csocket = "e8d9e0bb248c521c2c7fa01e1c6a116d929c41b4"
+                                     ''',
+                                 },
                              ],
                              )
     def test_good(self, input_, id_, occurrence):


### PR DESCRIPTION
from SRC_URI to identify variables names.
In before this issue was also hidden due to too high confidence setting in the best match function.

Lower the confidence to 0.5 and add named resources for at leats SRCREV_{x} pattern as valid and known variables.

Closes #468

# Pull request checklist

## Bugfix

- [x] A testcase was added to test the behavior

## New feature

- [ ] A testcase was added to test the behavior
- [ ] New functions are documented with docstrings
- [ ] No debug code is left
- [ ] README.md was updated to reflect the changes (check even if n.a.)
