### PR TITLE
Fix messageformat not passed to thread

### DIFF
--- a/oelint_adv/__main__.py
+++ b/oelint_adv/__main__.py
@@ -20,6 +20,7 @@ from oelint_parser.rpl_regex import RegexRpl
 from oelint_adv.cls_rule import Rule
 from oelint_adv.cls_rule import load_rules
 from oelint_adv.color import set_colorize
+from oelint_adv.rule_file import get_messageformat
 from oelint_adv.rule_file import get_rulefile
 from oelint_adv.rule_file import get_suppressions
 from oelint_adv.rule_file import set_inlinesuppressions
@@ -281,7 +282,9 @@ def flatten(list_):
     return flat
 
 
-def group_run(group, quiet, fix, jobs, rules, nobackup):
+def group_run(group, quiet, fix, jobs, rules, nobackup, messageformat):
+    set_messageformat(messageformat)
+
     fixedfiles = []
     stash = Stash(quiet)
     for f in group:
@@ -360,7 +363,8 @@ def run(args):
         with mp.Pool(processes=args.jobs) as pool:
             try:
                 issues = flatten(pool.map(partial(group_run, quiet=args.quiet, fix=args.fix,
-                                                  jobs=args.jobs, rules=rules, nobackup=args.nobackup), groups))
+                                                  jobs=args.jobs, rules=rules, nobackup=args.nobackup,
+                                                  messageformat=get_messageformat()), groups))
             finally:
                 pool.close()
                 pool.join()


### PR DESCRIPTION
The message format is stored as a global variable, but globals are not shared between processes. Therefore, we must explicitly pass it as a parameter.

Closes #472.

This is undoubtedly an ugly solution. Please feel free to suggest more appropriate solutions. I am more than happy to assist in resolving this issue.

# Pull request checklist

## Bugfix

- [ ] A testcase was added to test the behavior

## New feature

- [ ] A testcase was added to test the behavior
- [x] New functions are documented with docstrings
- [x] No debug code is left
- [x] README.md was updated to reflect the changes (check even if n.a.)
