### PR TITLE
misspell: bail out earlier for known vars

### DIFF
--- a/oelint_adv/rule_base/rule_var_misspell.py
+++ b/oelint_adv/rule_base/rule_var_misspell.py
@@ -28,16 +28,16 @@ class VarMisspell(Rule):
         _pkgs = get_valid_package_names(stash, _file, strippn=True)
         for i in items:
             _cleanvarname = i.VarName
+            if _cleanvarname in CONSTANTS.VariablesKnown:
+                continue
+            if _cleanvarname in _extras:
+                continue
             for pkg in _pkgs:
                 if not pkg:
                     continue  # pragma: no cover
                 if _cleanvarname.endswith(pkg):
                     _cleanvarname = ''.join(
                         _cleanvarname.rsplit(pkg, 1))  # pragma: no cover
-            if _cleanvarname in CONSTANTS.VariablesKnown:
-                continue
-            if _cleanvarname in _extras:
-                continue
             _used = False
             for a in _all:
                 if a == i:

--- a/tests/test_class_oelint_vars_misspell.py
+++ b/tests/test_class_oelint_vars_misspell.py
@@ -70,6 +70,17 @@ class TestClassOelintVarsMispell(TestBaseClass):
 
                                      ''',
                                  },
+                                 {
+                                     'abc.bb':
+                                     '''
+                                     DEPENDS:qemux86 = "something"
+
+                                     SRC_URI = "git://github.com/znc/znc.git;name=abc;branch=master;protocol=https \\
+                                                git://github.com/jimloco/Csocket.git;destsuffix=git/third_party/Csocket;name=Csocket;branch=master;protocol=https"
+                                     SRCREV_abc = "bf253640d33d03331310778e001fb6f5aba2989e"
+                                     SRCREV_Csocket = "e8d9e0bb248c521c2c7fa01e1c6a116d929c41b4"
+                                     ''',
+                                 },
                              ],
                              )
     def test_good(self, input_, id_, occurrence):


### PR DESCRIPTION
so we could catch valid vars like expanded statements of SRCREV_${PN} from the extra resources list.
The error surfaced only if a named resource has the very same name as one of the valid package names.

Closes #468

# Pull request checklist

## Bugfix

- [x] A testcase was added to test the behavior

## New feature

- [ ] A testcase was added to test the behavior
- [ ] New functions are documented with docstrings
- [ ] No debug code is left
- [ ] README.md was updated to reflect the changes (check even if n.a.)
