### PR TITLE
add oelint.vars.virtual rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ Rules marked with **[S]** can have multiple sub-IDs
 * oelint.vars.summary80chars - SUMMARY should max. be 80 characters long
 * oelint.vars.summarylinebreaks - No line breaks in SUMMARY
 * oelint.vars.valuequoted - Variable values should be properly quoted
+* oelint.vars.virtual - no virtual/ items in RDEPENDS/RPROVIDES
 
 ### Non-default rulesets
 

--- a/oelint_adv/rule_base/rule_vars_virtual.py
+++ b/oelint_adv/rule_base/rule_vars_virtual.py
@@ -1,0 +1,23 @@
+from typing import List, Tuple
+
+from oelint_parser.cls_item import Variable
+from oelint_parser.cls_stash import Stash
+
+from oelint_adv.cls_rule import Rule
+
+
+class VarsVirtualProvDep(Rule):
+    def __init__(self) -> None:
+        super().__init__(id='oelint.vars.virtual',
+                         severity='error',
+                         message='{var} can not contain virtual/ items')
+
+    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+        res = []
+        items: List[Variable] = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
+                                                  attribute=Variable.ATTR_VAR, attributeValue=['RDEPENDS', 'RPROVIDES'])
+
+        for i in items:
+            if any(x.startswith('virtual/') for x in i.get_items() if 'remove' not in i.SubItems):
+                res += self.finding(i.Origin, i.InFileLine, override_msg=self.Msg.format(var=i.VarName))
+        return res

--- a/tests/test_class_oelint_vars_virtual.py
+++ b/tests/test_class_oelint_vars_virtual.py
@@ -1,0 +1,75 @@
+import pytest  # noqa: I900
+
+from .base import TestBaseClass
+
+
+class TestClassOelintVarsVirtual(TestBaseClass):
+
+    @pytest.mark.parametrize('id_', ['oelint.vars.virtual'])
+    @pytest.mark.parametrize('occurrence', [1])
+    @pytest.mark.parametrize('input_',
+                             [
+                                 {
+                                     'oelint_adv_test.bb':
+                                     '''
+                                     RDEPENDS:${PN} = "virtual/a"
+                                     ''',
+                                 },
+                                 {
+                                     'oelint_adv_test.bb':
+                                     '''
+                                     RPROVIDES:${PN} = "virtual/a"
+                                     ''',
+                                 },
+                                 {
+                                     'oelint_adv_test.bb':
+                                     '''
+                                     require something.inc
+                                     RDEPENDS:${PN}-doc = "abc def virtual/a"
+                                     ''',
+                                 },
+                             ],
+                             )
+    def test_bad(self, input_, id_, occurrence):
+        self.check_for_id(self._create_args(input_), id_, occurrence)
+
+    @pytest.mark.parametrize('id_', ['oelint.vars.dependsappend'])
+    @pytest.mark.parametrize('occurrence', [0])
+    @pytest.mark.parametrize('input_',
+                             [
+                                 {
+                                     'oelint_adv_test.bb':
+                                     'RDEPENDS:${PN} += "foo"',
+                                 },
+                                 {
+                                     'oelint_adv_test.bb':
+                                     'RDEPENDS:${PN}:append = "foo"',
+                                 },
+                                 {
+                                     'oelint_adv_test.bb':
+                                     'RPROVIDES:${PN} += "foo"',
+                                 },
+                                 {
+                                     'oelint_adv_test.bb':
+                                     'RPROVIDES:${PN}:append = "foo"',
+                                 },
+                                 {
+                                     'oelint_adv_test.bb':
+                                     'RDEPENDS:${PN}:remove = "virtual/a"',
+                                 },
+                                 {
+                                     'oelint_adv_test.bb':
+                                     'RPROVIDES:${PN}:remove = "virtual/a"',
+                                 },
+                                 {
+                                     'oelint_adv_test.bb':
+                                     'RPROVIDES:${PN} += "virtual-reality"',
+                                 },
+                                 {
+                                     'oelint_adv_test.bb':
+                                     'RPROVIDES:${PN}:append = "virtual-reality"',
+                                 },
+                             ],
+                             )
+    def test_good(self, input_, id_, occurrence):
+        self.check_for_id(self._create_args(input_), id_, occurrence)


### PR DESCRIPTION
to check for virtual/items in RDEPENDS and
RPROVIDES

Closes #490

# Pull request checklist

## Bugfix

- [ ] A testcase was added to test the behavior

## New feature

- [x] A testcase was added to test the behavior
- [ ] New functions are documented with docstrings
- [x] No debug code is left
- [x] README.md was updated to reflect the changes (check even if n.a.)
