### PR TITLE
rule_tasks_doc_strings: fix anonymous function check

### DIFF
--- a/oelint_adv/rule_base/rule_tasks_doc_strings.py
+++ b/oelint_adv/rule_base/rule_tasks_doc_strings.py
@@ -16,7 +16,7 @@ class TaskDocStrings(Rule):
     def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
         res = []
         for item in stash.GetItemsFor(filename=_file, classifier=Function.CLASSIFIER):
-            if item.FuncName in CONSTANTS.FunctionsKnown or item.FuncName in ['', 'anonymous']:
+            if item.FuncName in CONSTANTS.FunctionsKnown or item.FuncName in ['', '__anonymous']:
                 # Skip for builtin tasks or anonymous python functions
                 continue
             if item.IsAppend():


### PR DESCRIPTION
Latest versions of the Bitbake user manual recommend naming these functions "__anonymous".

See https://docs.yoctoproject.org/bitbake/2.6/bitbake-user-manual/bitbake-user-manual-metadata.html#anonymous-python-functions.
