### PR TITLE
multilineident: Accept indentation based on non-empty first lines

### DIFF
--- a/tests/test_class_oelint_vars_multilineident.py
+++ b/tests/test_class_oelint_vars_multilineident.py
@@ -18,6 +18,58 @@ class TestClassOelintVarsMultilineIdent(TestBaseClass):
                                      "
                                      ''',
                                  },
+                                 {
+                                     'oelint_adv_test.bb':
+                                     '''
+                                     D = "a \\
+                                     e \\
+                                         "
+                                     ''',
+                                 },
+                                 {
+                                     'oelint_adv_test.bb':
+                                     '''
+                                     D = "    a \\
+                                         e \\
+                                         "
+                                     ''',
+                                 },
+                                 {
+                                     'oelint_adv_test.bb':
+                                     '''
+                                     A = "a \\
+                                       b \\
+                                          c \\
+                                     "
+                                     ''',
+                                 },
+                                 {
+                                     'oelint_adv_test.bb':
+                                     '''
+                                     A = "\\
+                                         b \\
+                                          c \\
+                                     "
+                                     ''',
+                                 },
+                                 {
+                                     'oelint_adv_test.bb':
+                                     '''
+                                     A:append = "a \\
+                                              b \\
+                                                 c \\
+                                     "
+                                     ''',
+                                 },
+                                 {
+                                     'oelint_adv_test.bb':
+                                     '''
+                                     A += "a \\
+                                        b \\
+                                           c \\
+                                     "
+                                     ''',
+                                 },
                              ],
                              )
     def test_bad(self, input_, id_, occurrence):
@@ -32,6 +84,7 @@ class TestClassOelintVarsMultilineIdent(TestBaseClass):
                                      '''
                                      A = "a \\
                                      b \\
+                                     c \\
                                          "
                                      ''',
                                  },
@@ -40,6 +93,7 @@ class TestClassOelintVarsMultilineIdent(TestBaseClass):
                                      '''
                                      D = "a \\
                                      e \\
+                                     f \\
                                          "
                                      ''',
                                  },
@@ -74,10 +128,47 @@ class TestClassOelintVarsMultilineIdent(TestBaseClass):
                                  {
                                      'oelint_adv_test.bb':
                                      '''
+                                     A = "    \\
+                                          a \\
+                                          b \\
+                                          e \\
+                                       "
+                                     ''',
+                                 },
+                                 {
+                                     'oelint_adv_test.bb':
+                                     '''
                                      A = "\\
                                          a \\
                                          b \\
                                          e \\
+                                     "
+                                     ''',
+                                 },
+                                 {
+                                     'oelint_adv_test.bb':
+                                     '''
+                                     A = "a \\
+                                          b \\
+                                          c \\
+                                     "
+                                     ''',
+                                 },
+                                 {
+                                     'oelint_adv_test.bb':
+                                     '''
+                                     A:append = "a \\
+                                                 b \\
+                                                 c \\
+                                     "
+                                     ''',
+                                 },
+                                 {
+                                     'oelint_adv_test.bb':
+                                     '''
+                                     A += "a \\
+                                           b \\
+                                           c \\
                                      "
                                      ''',
                                  },


### PR DESCRIPTION
This PR makes the oelint.vars.multilineident check handle variables that are formatted according to [the current Yocto style guide](https://docs.yoctoproject.org/dev/contributor-guide/recipe-style-guide.html#recipe-formatting) - see #515 for discussion.
In short: if a variable is formatted like this, the current state of the linter shows a warning because the alignment of the first line is determined to be 0:
```
FOO = "this line is \
       long \
       "
```

The new heuristic is: iff there is non-whitespace content in the first physical line of a multi-line assignment, a variable is assumed to be aligned after the `"`. If this is the case, that point will be used as the desired indentation instead of trying to determine a best-fit indentation.

All previous formats are still accepted and tests for this format are added.

Would you be willing to accept this change in behaviour?


I would classify it as a bugfix for the purpose of the PR checklist - but the "New feature" checklist is fulfilled as well.

# Pull request checklist

## Bugfix

- [x] A testcase was added to test the behavior

## New feature

- [x] A testcase was added to test the behavior
- [x] New functions are documented with docstrings
- [x] No debug code is left
- [x] README.md was updated to reflect the changes (check even if n.a.)
