### PR TITLE
oelint.vars.bbclassextend: don't warn on image or packagegroup

### DIFF
--- a/oelint_adv/rule_base/rule_vars_bbclassextends.py
+++ b/oelint_adv/rule_base/rule_vars_bbclassextends.py
@@ -13,6 +13,8 @@ class VarBbclassextend(Rule):
                          message='BBCLASSEXTEND should be set if possible')
 
     def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+        if stash.IsPackageGroup(_file) or stash.IsImage(_file):
+            return []
         res = []
         items: List[Variable] = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
                                                   attribute=Variable.ATTR_VAR, attributeValue='BBCLASSEXTEND')

--- a/tests/test_class_oelint_var_bbclassextend.py
+++ b/tests/test_class_oelint_var_bbclassextend.py
@@ -46,6 +46,14 @@ class TestClassOelintVarBBClassExtend(TestBaseClass):
                                      'oelint_adv_test.bb':
                                      'inherit nativesdk',
                                  },
+                                 {
+                                     'oelint_adv_test.bb':
+                                     'inherit core-image',
+                                 },
+                                 {
+                                     'oelint_adv_test.bb':
+                                     'inherit packagegroup',
+                                 },
                              ],
                              )
     def test_good(self, input_, id_, occurrence):


### PR DESCRIPTION
Another tiny fix/enhancement to reduce clutter in the output:

Usually, I think one would probably not try to build a -native or -nativesdk variant of an image or a packagegroup recipe. So skip this warning in these cases.

This is the same logic as in rule_file_underscores.py, which also skips these two kinds of recipes.

# Pull request checklist

## Bugfix

- [x] A testcase was added to test the behavior