### PR TITLE
rule: add wikiurl message format

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,6 +391,7 @@ The following placeholder symbols will be automatically replaced
 | {severity} | severity of the finding    |
 | {id}       | error-ID of the finding    |
 | {msg}      | description of the finding |
+| {wikiurl}  | a link to the online wiki  |
 
 ## Configuration file
 

--- a/oelint_adv/cls_rule.py
+++ b/oelint_adv/cls_rule.py
@@ -6,9 +6,10 @@ import sys
 from typing import Iterable, List, Tuple
 
 from colorama import Style
+from oelint_parser.cls_stash import Stash
 
 from oelint_adv.state import State
-from oelint_parser.cls_stash import Stash
+from oelint_adv.version import __version__
 
 
 class Rule:
@@ -144,8 +145,11 @@ class Rule:
             _color = self._state.get_color_by_severity(_severity)
             _style = Style.RESET_ALL
 
+        wikiurl = f'https://github.com/priv-kweihmann/oelint-adv/blob/{__version__}/docs/wiki/{self.ID}.md'
+
         _msg = self._state.get_messageformat().format(path=_path, line=_line, severity=_severity,
-                                                      id=_display_id, msg=override_msg)
+                                                      id=_display_id, msg=override_msg,
+                                                      wikiurl=wikiurl)
 
         return [((_path, _line), f'{_color}{_msg}{_style}')]
 

--- a/tests/test_user_interface.py
+++ b/tests/test_user_interface.py
@@ -611,6 +611,28 @@ class TestClassIntegration(TestBaseClass):
                                      'oelint adv-test.bb':
                                      '''
                                      VAR = "1"
+                                     INSANE_SKIP:${PN} = "foo"
+                                     ''',
+                                 },
+                             ],
+                             )
+    def test_messageformat_wikiurl(self, input_):
+        # local imports only
+        from oelint_adv.__main__ import run
+        from oelint_adv.version import __version__
+
+        _args = self._create_args(
+            input_, extraopts=['--messageformat="{wikiurl}"'])
+        issues = [x[1] for x in run(_args)]
+        assert (any(
+            [x for x in issues if f'https://github.com/priv-kweihmann/oelint-adv/blob/{__version__}/docs/wiki/oelint.vars.insaneskip.md' in x]))
+
+    @pytest.mark.parametrize('input_',
+                             [
+                                 {
+                                     'oelint adv-test.bb':
+                                     '''
+                                     VAR = "1"
                                      INSANE_SKIP_${PN} = "foo"
                                      ''',
                                  },


### PR DESCRIPTION
which prints a link to the online wiki for the particular finding. Off by default - can be enabled by running with `--messageformat="{wikiurl}"`

Closes #535

# Pull request checklist

## Bugfix

- [ ] A testcase was added to test the behavior

## New feature

- [x] A testcase was added to test the behavior
- [x] ``wiki-creator.py`` was run and a new wiki document was filled with information
- [x] New functions are documented with docstrings
- [x] No debug code is left
- [x] README.md was updated to reflect the changes (check even if n.a.)
