### PR TITLE
Replace deprecated setup.py commands in CI

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -26,7 +26,7 @@ jobs:
         cache: 'pip'
     - name: prepare
       run: |
-        python3 -m pip install --upgrade pip
+        python3 -m pip install --upgrade pip build
         pip install --upgrade setuptools 
         pip install -r requirements.txt
         pip install -r requirements-dev.txt
@@ -37,9 +37,9 @@ jobs:
     - name: test (pytest)
       run: pytest
     - name: build
-      run: python3 setup.py build sdist bdist_wheel --universal
+      run: python3 -m build --sdist --wheel
     - name: install
-      run: python3 setup.py install --user
+      run: python3 -m pip install --user dist/*.whl
     - name: test (installed)
       run: |
         oelint-adv --help


### PR DESCRIPTION
This commit replaces the deprecated `setup.py` commands in the GitHub Actions CI configuration with the recommended standards-based tools. The `build` and `pip` modules are now used to build and install the package. This change aligns with the Python packaging ecosystem's move towards standardization.

Closes https://github.com/priv-kweihmann/oelint-adv/issues/543
