### PR TITLE
Add switch to hide messages of any given severity

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ required python libraries on your own. See [requirements.txt](requirements.txt) 
 
 ```shell
 usage: oelint-adv [-h] [--suppress SUPPRESS] [--output OUTPUT] [--fix] [--nobackup] [--addrules ADDRULES [ADDRULES ...]]
-                  [--customrules CUSTOMRULES [CUSTOMRULES ...]] [--rulefile RULEFILE] [--jobs JOBS] [--color] [--quiet] [--noinfo]
-                  [--nowarn] [--relpaths] [--noid] [--messageformat MESSAGEFORMAT] [--constantmods CONSTANTMODS [CONSTANTMODS ...]] [--print-rulefile] [--exit-zero]
+                  [--customrules CUSTOMRULES [CUSTOMRULES ...]] [--rulefile RULEFILE] [--jobs JOBS] [--color] [--quiet] [--hide SEVERITY]
+                  [--relpaths] [--noid] [--messageformat MESSAGEFORMAT] [--constantmods CONSTANTMODS [CONSTANTMODS ...]] [--print-rulefile] [--exit-zero]
                   [--version]
                   [files ...]
 
@@ -69,8 +69,7 @@ options:
   --jobs JOBS           Number of jobs to run (default all cores)
   --color               Add color to the output based on the severity
   --quiet               Print findings only
-  --noinfo              Don't print information level findings
-  --nowarn              Don't print warning level findings
+  --hide SEVERITY       Hide mesesages of specified severity
   --relpaths            Show relative paths instead of absolute paths in results
   --noid                Don't show the error-ID in the output
   --messageformat MESSAGEFORMAT
@@ -412,8 +411,8 @@ To skip the loading of any configuration file, set `OELINT_SKIP_CONFIG` to a non
 
 ```ini
 [oelint]
-# this will set the --nowarn parameter automatically
-nowarn = True
+# this will set the --hide warning parameter automatically
+hide = warning
 # this will set A + B as suppress item
 # use indent (tab) and line breaks for multiple items
 suppress = 

--- a/docs/.oelint.cfg.example
+++ b/docs/.oelint.cfg.example
@@ -3,5 +3,5 @@ messageformat={severity}:{id}:{msg}
 suppress=
     oelint.tabs.notabs
     oelint.task.docstrings
-noinfo=True
+hide=info
 exit-zero=True

--- a/oelint_adv/__main__.py
+++ b/oelint_adv/__main__.py
@@ -45,10 +45,13 @@ def create_argparser() -> argparse.ArgumentParser:
                         help='Add color to the output based on the severity')
     parser.add_argument('--quiet', action='store_true', default=False,
                         help='Print findings only')
+    parser.add_argument('--hide', default=None, action='append',
+                        choices=['info', 'warning', 'error'],
+                        help='Hide mesesages of specified severity')
     parser.add_argument('--noinfo', action='store_true', default=False,
-                        help='Don\'t print information level findings')
+                        help=argparse.SUPPRESS)
     parser.add_argument('--nowarn', action='store_true', default=False,
-                        help='Don\'t print warning level findings')
+                        help=argparse.SUPPRESS)
     parser.add_argument('--relpaths', action='store_true', default=False,
                         help='Show relative paths instead of absolute paths in results')
     parser.add_argument('--messageformat', default='{path}:{line}:{severity}:{id}:{msg}',

--- a/oelint_adv/cls_rule.py
+++ b/oelint_adv/cls_rule.py
@@ -122,9 +122,11 @@ class Rule:
         if any(x in self._state.get_suppressions() for x in _id):
             return []
         _severity = severity_override or self.get_severity(appendix)
-        if _severity == 'info' and self._state.get_noinfo():
+        if _severity == 'info' and self._state.get_hide('info'):
             return []
-        if _severity == 'warning' and self._state.get_nowarn():
+        if _severity == 'warning' and self._state.get_hide('warning'):
+            return []
+        if _severity == 'error' and self._state.get_hide('error'):
             return []
         if _line <= 0:
             # Fix those issues, that don't come with a line

--- a/oelint_adv/state.py
+++ b/oelint_adv/state.py
@@ -10,8 +10,7 @@ class State():
         self.color = False
         self.inline_suppressions = {}
         self.messageformat = ''
-        self.no_info = False
-        self.no_warn = False
+        self.hide = {'error': False, 'warning': False, 'info': False}
         self.rel_path = False
         self.rule_file = {}
         self.suppression = []
@@ -38,21 +37,13 @@ class State():
         """
         return self.__colors_by_severity.get(severity, '')
 
-    def get_noinfo(self) -> bool:
-        """--noinfo flag set
+    def get_hide(self, severity) -> bool:
+        """--hide severity is set
 
         Returns:
-            bool: noinfo flag is set
+            bool: hide messages of given severity
         """
-        return self.no_info
-
-    def get_nowarn(self) -> bool:
-        """--nowarn flag set
-
-        Returns:
-            bool: nowarn flag is set
-        """
-        return self.no_warn
+        return self.hide[severity]
 
     def get_relpaths(self) -> bool:
         """--relpath flag is set

--- a/tests/test_configfile.py
+++ b/tests/test_configfile.py
@@ -21,16 +21,16 @@ class TestConfigFile(TestBaseClass):
         # Test the default
         _args = self._create_args(input_)
 
-        assert not _args.nowarn
+        assert not _args.hide
 
         # test the override from config file
         # here loaded via environment variable
-        _cstfile = self._create_tempfile('oelint.cfg', '[oelint]\nnowarn=True')
+        _cstfile = self._create_tempfile('oelint.cfg', '[oelint]\nhide=warning')
         os.environ['OELINT_CONFIG'] = _cstfile
         _args = self._create_args(input_)
         del os.environ['OELINT_CONFIG']
 
-        assert _args.nowarn
+        assert _args.hide == ['warning']
 
     @pytest.mark.parametrize('input_',
                              [
@@ -43,16 +43,16 @@ class TestConfigFile(TestBaseClass):
         # Test the default
         _args = self._create_args(input_)
 
-        assert not _args.nowarn
+        assert not _args.hide
 
         # test the override from config file
         # here loaded via home folder
         _cstfile = self._create_tempfile(
-            '.oelint.cfg', '[oelint]\nnowarn=True')
+            '.oelint.cfg', '[oelint]\nhide=warning')
         os.environ['HOME'] = os.path.dirname(_cstfile)
         _args = self._create_args(input_)
 
-        assert _args.nowarn
+        assert _args.hide == ['warning']
 
     @pytest.mark.parametrize('input_',
                              [
@@ -65,19 +65,19 @@ class TestConfigFile(TestBaseClass):
         # Test the default
         _args = self._create_args(input_)
 
-        assert not _args.nowarn
+        assert not _args.hide
 
         # test the override from config file
         # here loaded from current workdir
         _cstfile = self._create_tempfile(
-            '.oelint.cfg', '[oelint]\nnowarn=True')
+            '.oelint.cfg', '[oelint]\nhide=warning')
 
         _cwd = os.getcwd()
         os.chdir(os.path.dirname(_cstfile))
         _args = self._create_args(input_)
         os.chdir(_cwd)
 
-        assert _args.nowarn
+        assert _args.hide == ['warning']
 
     @pytest.mark.parametrize('input_',
                              [
@@ -90,12 +90,12 @@ class TestConfigFile(TestBaseClass):
         # Test the default
         _args = self._create_args(input_)
 
-        assert not _args.nowarn
+        assert not _args.hide
 
         # test the override from config file
         # here loaded from current workdir
         _cstfile = self._create_tempfile(
-            '.oelint.cfg', '[oelint]\nnowarn=True')
+            '.oelint.cfg', '[oelint]\nhide=warning')
         
         os.environ['OELINT_SKIP_CONFIG'] = '1'
 
@@ -106,7 +106,7 @@ class TestConfigFile(TestBaseClass):
 
         os.environ.pop('OELINT_SKIP_CONFIG')
 
-        assert not _args.nowarn
+        assert not _args.hide
 
     @pytest.mark.parametrize('input_',
                              [
@@ -171,6 +171,7 @@ class TestConfigFile(TestBaseClass):
             'addrules',
             'customrules',
             'suppress',
+            'hide',
         ]:
             _cstfile = self._create_tempfile(
                 '.oelint.cfg', '[oelint]\n{item}=\t+True\n\t-False'.format(item=_option))
@@ -207,16 +208,16 @@ class TestConfigFile(TestBaseClass):
         # Test the default
         _args = self._create_args(input_)
 
-        assert not _args.nowarn
+        assert not _args.hide
 
         # test the override from config file
         # here loaded via environment variable but with a broken file
-        _cstfile = self._create_tempfile('oelint.cfg', '[oel]\nnowarn=')
+        _cstfile = self._create_tempfile('oelint.cfg', '[oel]\nhide=')
         os.environ['OELINT_CONFIG'] = _cstfile
         _args = self._create_args(input_)
         del os.environ['OELINT_CONFIG']
 
-        assert not _args.nowarn
+        assert not _args.hide
 
     @pytest.mark.parametrize('input_',
                              [

--- a/tests/test_user_interface.py
+++ b/tests/test_user_interface.py
@@ -187,7 +187,7 @@ class TestClassIntegration(TestBaseClass):
         }
         '''
         _extra_opts = [
-            '--rulefile={file}'.format(file=self._create_tempfile('rulefile', __cnt)), '--noinfo']
+            '--rulefile={file}'.format(file=self._create_tempfile('rulefile', __cnt)), '--hide', 'info']
         self.check_for_id(self._create_args(input_, _extra_opts),
                           'oelint.var.suggestedvar.CVE_PRODUCT', 0)
 
@@ -519,6 +519,44 @@ class TestClassIntegration(TestBaseClass):
                                  },
                              ],
                              )
+    def test_hide_info(self, input_):
+        # local imports only
+        from oelint_adv.__main__ import run
+
+        _args = self._create_args(input_, extraopts=['--hide', 'info'])
+        issues = [x[1] for x in run(_args)]
+        assert (not any([x for x in issues if ':info:' in x]))
+
+    @pytest.mark.parametrize('input_',
+                             [
+                                 {
+                                     'oelint adv-test.bb':
+                                     '''
+                                     VAR = "1"
+                                     INSANE_SKIP_${PN} = "foo"
+                                     ''',
+                                 },
+                             ],
+                             )
+    def test_hide_warning(self, input_):
+        # local imports only
+        from oelint_adv.__main__ import run
+
+        _args = self._create_args(input_, extraopts=['--hide', 'warning'])
+        issues = [x[1] for x in run(_args)]
+        assert (not any([x for x in issues if ':warning:' in x]))
+
+    @pytest.mark.parametrize('input_',
+                             [
+                                 {
+                                     'oelint adv-test.bb':
+                                     '''
+                                     VAR = "1"
+                                     INSANE_SKIP_${PN} = "foo"
+                                     ''',
+                                 },
+                             ],
+                             )
     def test_noinfo(self, input_):
         # local imports only
         from oelint_adv.__main__ import run
@@ -693,7 +731,7 @@ class TestClassIntegration(TestBaseClass):
             'constants.json', '{"oelint.var.mandatoryvar.DESCRIPTION": "warning", "oelint.var.mandatoryvar": "info" }')
 
         _args = self._create_args(
-            input_, extraopts=['--rulefile={file}'.format(file=_cstfile), '--noinfo'])
+            input_, extraopts=['--rulefile={file}'.format(file=_cstfile), '--hide', 'info'])
         issues = [x[1] for x in run(_args)]
         assert (not any(issues))
 
@@ -733,7 +771,7 @@ class TestClassIntegration(TestBaseClass):
             'constants.json', '{"oelint.var.mandatoryvar.DESCRIPTION": "warning", "oelint.var.mandatoryvar": "info" }')
 
         _args = self._create_args(
-            input_, extraopts=['--rulefile={file}'.format(file=_cstfile), '--noinfo'])
+            input_, extraopts=['--rulefile={file}'.format(file=_cstfile), '--hide', 'info'])
         issues = [x[1] for x in run(_args)]
         assert (any(issues))
 

--- a/tests/test_user_interface.py
+++ b/tests/test_user_interface.py
@@ -552,6 +552,25 @@ class TestClassIntegration(TestBaseClass):
                                      'oelint adv-test.bb':
                                      '''
                                      VAR = "1"
+                                     FILES = "foo"
+                                     ''',
+                                 },
+                             ],
+                             )
+    def test_hide_error(self, input_):
+        # local imports only
+        from oelint_adv.__main__ import run
+
+        _args = self._create_args(input_, extraopts=['--hide', 'error'])
+        issues = [x[1] for x in run(_args)]
+        assert (not any([x for x in issues if ':error:' in x]))
+
+    @pytest.mark.parametrize('input_',
+                             [
+                                 {
+                                     'oelint adv-test.bb':
+                                     '''
+                                     VAR = "1"
                                      INSANE_SKIP_${PN} = "foo"
                                      ''',
                                  },


### PR DESCRIPTION
As of now only switches to hide info and warning severity messages are present.
Both locally and in CI builds it can be useful to filter findings based on the severity
of all levels.
To avoid adding two more switches, the two present switches have been
removed in favor of a generic "hide" switch to disable specified
severity level messages.

# Pull request checklist

## Bugfix

- [ ] A testcase was added to test the behavior

## New feature

- [x] A testcase was added to test the behavior
- [x] ``wiki-creator.py`` was run and a new wiki document was filled with information
- [x] New functions are documented with docstrings
- [x] No debug code is left
- [x] README.md was updated to reflect the changes (check even if n.a.)
