### PR TITLE
__main__.py: Improve status report through exit codes

### DIFF
--- a/oelint_adv/__main__.py
+++ b/oelint_adv/__main__.py
@@ -109,7 +109,8 @@ def main() -> int:  # pragma: no cover
         import traceback
         print('OOPS - That shouldn\'t happen: {e} - {files}'.format(e=e, files=args.files))
         traceback.print_exc()
-        sys.exit(-1)
+        # Not using os.EX_SOFTWARE here because it is only available on Unix
+        sys.exit(70)
 
     if args.output != sys.stderr:
         args.output = open(args.output, 'w')
@@ -119,7 +120,8 @@ def main() -> int:  # pragma: no cover
     if args.output != sys.stderr:
         args.output.close()
 
-    exit_code = len(issues) if not args.exit_zero else 0
+    # Exit 1 in case of any issue, except when --exit-zero was used.
+    exit_code = 0 if args.exit_zero else len(issues) and 1
     sys.exit(exit_code)
 
 


### PR DESCRIPTION
Always exit non-zero when issues are encountered.

In case the number of issues was 256 or its multiples, the executable
would exit `0` as values greater than 255 overflow the range of valid
exit codes (0..255).  Example:

```
$ python -c 'import sys; sys.exit(256)'; echo $?
0
```

In case of issues identified in bitbake metadata, hardcode the exit
code to 1.  Ideally the exit code should encode the type of issues
identified, for example, using the convention assumed by pylint
(https://pylint.pycqa.org/en/v3.2.3/user_guide/usage/run.html#exit-codes),
but this is not done in this change, as it requires identifying the
type of changes in the object returned by the `run` function.

Also, make the code exit according to the valid range for exit codes
and adhere to the conventions in `/usr/include/sysexits.h`, namely

```
  #define EX_SOFTWARE     70      /* internal software error */
```

for internal software error.

`os.EX_SOFTWARE` has not been explicitly used because it might not be
supported by platforms other than Unix.  Its value (70) has been used
instead, since we have to use an arbitrary non-zero value in the valid
exit code range anyway.

Signed-off-by: Mario Domenech Goulart <Mario.Goulart@bmw.de>

