### PR TITLE
rule_var_depends_append: improve message

### DIFF
--- a/oelint_adv/rule_base/rule_var_depends_append.py
+++ b/oelint_adv/rule_base/rule_var_depends_append.py
@@ -10,7 +10,7 @@ class VarDependsAppend(Rule):
     def __init__(self) -> None:
         super().__init__(id='oelint.vars.dependsappend',
                          severity='error',
-                         message='DEPENDS should only be appended, not overwritten as an include or inherit')
+                         message='DEPENDS should only be appended, not overwritten after an include or inherit')
 
     def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
         res = []


### PR DESCRIPTION
The `rule_var_depends_append` outputs the message "DEPENDS should only be appended, not overwritten as an include or inherit".

This is confusing and does not really describe what rule actually checks: It verifies that `DEPENDS` only get appended and not overwritten **after** any include/inherit operation - which completely makes sense since the `DEPENDS` might have been set by the included file.

To me, the current wording indicates that the DEPENDS was set/changed by the included file so I had to check the actual implementation to figure out the reason for this finding.
This PR changes the message to "DEPENDS should only be appended, not overwritten **after** an include or inherit" to make this more clear.

# Pull request checklist

## Bugfix

~- [ ] A testcase was added to test the behavior~ This MR only affects the message and is not covered by the current test.
