### PR TITLE
core/post: deserialize all options before tweaks

### DIFF
--- a/oelint_adv/core.py
+++ b/oelint_adv/core.py
@@ -360,9 +360,6 @@ def create_lib_arguments(files: List[str],
 def arguments_post(args: argparse.Namespace) -> argparse.Namespace:  # noqa: C901 - complexity is still okay
     setattr(args, 'state', State())  # noqa: B010
 
-    # Apply release specific tweaks
-    args = Tweaks.tweak_args(args)
-
     # Convert boolean symbols
     for _option in [
         'color',
@@ -394,6 +391,9 @@ def arguments_post(args: argparse.Namespace) -> argparse.Namespace:  # noqa: C90
                     getattr(args, _option) or '').split('\n') if x])
         except AttributeError:  # pragma: no cover
             pass  # pragma: no cover
+
+    # Apply release specific tweaks
+    args = Tweaks.tweak_args(args)
 
     if args.files == [] and not args.print_rulefile and not args.clear_caches:
         raise argparse.ArgumentTypeError('no input files')


### PR DESCRIPTION
as e.g. constantmods is expected to be a list,
but if it's set through the config file, it likely is still a string, hence the need to deserialize before applying the tweaks

Closes #635

