### PR TITLE
oelint.var.multiinclude: base rule on paths

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 anytree ~= 2.12
 argcomplete ~= 3.5
 colorama ~= 0.4
-oelint-parser ~= 6.2
+oelint-parser ~= 6.3
 urllib3 ~= 2.2

--- a/tests/test_class_oelint_var_multiinclude.py
+++ b/tests/test_class_oelint_var_multiinclude.py
@@ -25,6 +25,18 @@ class TestClassOelintVarMultiInclude(TestBaseClass):
                                      include abc.inc
                                      ''',
                                  },
+                                 {
+                                     'oelint_adv_test.bb':
+                                     '''
+                                     require abc.inc
+                                     B = "2"
+                                     include abc.inc
+                                     ''',
+                                     'abc.inc':
+                                     '''
+                                     A = "1"
+                                     ''',
+                                 },
                              ],
                              )
     def test_bad(self, input_, id_, occurrence):
@@ -40,6 +52,24 @@ class TestClassOelintVarMultiInclude(TestBaseClass):
                                      include abc.inc
                                      B = "2"
                                      include abc2.inc
+                                     ''',
+                                 },
+                                 {
+                                     'oelint_adv_test.bb':
+                                     '''
+                                     include abc.inc
+                                     ''',
+                                     'abc.inc':
+                                     '''
+                                     A = "1"
+                                     ''',
+                                     'dynamic-layers/test/oelint_adv_test.bb':
+                                     '''
+                                     include abc.inc
+                                     ''',
+                                     'dynamic-layers/test/abc.inc':
+                                     '''
+                                     A = "1"
                                      ''',
                                  },
                              ],


### PR DESCRIPTION
and do not just look at the include name, but
at the actual file included, as they could point
to very much different files.
Fix includes a bump of the parser lib to 6.3

Closes #640

# Pull request checklist

## Bugfix

- [x] A testcase was added to test the behavior

## New feature

- [ ] A testcase was added to test the behavior
- [ ] ``wiki-creator.py`` was run and a new wiki document was filled with information
- [ ] New functions are documented with docstrings
- [ ] No debug code is left
- [ ] README.md was updated to reflect the changes (check even if n.a.)
