### PR TITLE
oelint.file.underscores: accept dashes in version numbers

### DIFF
--- a/oelint_adv/rule_base/rule_file_underscores.py
+++ b/oelint_adv/rule_base/rule_file_underscores.py
@@ -19,12 +19,11 @@ class FileNoSpaces(Rule):
         if _ext in ['.bb']:  # pragma: no cover
             if stash.IsPackageGroup(_file) or stash.IsImage(_file):
                 return []
-            _sep = [x for x in _basename if x in ['_', '-']]
-            _us = [x for x in _sep if x == '_']
+            _us = [x for x in _basename if x == '_']
             if len(_us) > 1:
                 res += self.finding(_file, 1,
                                     override_msg='Filename should not contain more than one \'_\'')
-            elif not _us or _sep[-1] != '_':
+            elif not _us:
                 res += self.finding(
                     _file, 1, override_msg='Filename should contain at least one \'_\' in the end')
         return res

--- a/tests/test_class_oelint_file_underscores.py
+++ b/tests/test_class_oelint_file_underscores.py
@@ -10,7 +10,7 @@ class TestClassOelintFileUnderscores(TestBaseClass):
     @pytest.mark.parametrize('input_',
                              [
                                  {
-                                     'oelint_adv-test.bb':
+                                     'oelint_adv_test-1.2.3.bb':
                                      'VAR = "1"',
                                  },
                                  {
@@ -30,6 +30,14 @@ class TestClassOelintFileUnderscores(TestBaseClass):
     @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('input_',
                              [
+                                 {
+                                     'oelint_adv-test.bb':
+                                     'VAR = "1"',
+                                 },
+                                 {
+                                     'oelint-adv_test-1.2.3.bb':
+                                     'VAR = "1"',
+                                 },
                                  {
                                      'oelint_adv_test.bb':
                                      'inherit core-image',


### PR DESCRIPTION
The initial code is complaining about dashes in the version part of the filename for no really good reason.

Issue : https://github.com/priv-kweihmann/oelint-adv/issues/668

# Pull request checklist

## Bugfix

- [ X ] A testcase was added to test the behavior