### PR TITLE
core: fix inline suppression

### DIFF
--- a/oelint_adv/core.py
+++ b/oelint_adv/core.py
@@ -199,7 +199,7 @@ def group_run(group: List[Tuple],
     for item in stash.GetItemsFor(classifier=Comment.CLASSIFIER):
         for line in item.get_items():
             m = re.match(
-                r'^#\s+nooelint:\s+(?P<ids>[A-Za-z0-9\.,_ ]*)', line)
+                r'^#\s+nooelint:\s+(?P<ids>[A-Za-z0-9\.,_\s-]*)', line)
             if m:
                 if item.Origin not in inline_supp_map:  # pragma: no cover
                     inline_supp_map[item.Origin] = {}

--- a/tests/test_inlinesuppressions.py
+++ b/tests/test_inlinesuppressions.py
@@ -56,7 +56,7 @@ class TestClassInlineSuppressions(TestBaseClass):
     def test_inlinesuppressions_single_notmatching(self, input_):
         self.check_for_id(self._create_args(input_),
                           'oelint.vars.insaneskip', 1)
-        
+
     @pytest.mark.parametrize('input_',
                              [
                                  {
@@ -80,7 +80,7 @@ class TestClassInlineSuppressions(TestBaseClass):
                                     # nooelint: oelint.var.suggestedvar.BUGTRACKER,oelint.var.mandatoryvar.SUMMARY,oelint.var.bbclassextend
                                     INSANE_SKIP_${PN} = "foo"
                                     ''',
-                                 }
+                                 },
                              ],
                              )
     def test_inlinesuppressions_line_1(self, input_):
@@ -90,6 +90,23 @@ class TestClassInlineSuppressions(TestBaseClass):
                           'oelint.var.mandatoryvar.SUMMARY', 0)
         self.check_for_id(self._create_args(input_),
                           'oelint.var.bbclassextend', 0)
+
+    @pytest.mark.parametrize('input_',
+                             [
+                                 {
+                                     'oelint adv-test.bb':
+                                     '''
+                                     # nooelint: oelint.var.badimagefeature.allow-empty-password,oelint.var.badimagefeature.allow-root-login,oelint.var.badimagefeature.empty-root-password
+                                     IMAGE_FEATURES:append = " \
+                                        allow-empty-password allow-root-login empty-root-password \
+                                     "
+                                     ''',
+                                 },
+                             ],
+                             )
+    def test_inlinesuppressions_line_2(self, input_):
+        self.check_for_id(self._create_args(input_),
+                          'oelint.var.badimagefeature', 0)
 
     @pytest.mark.parametrize('input_',
                              [
@@ -128,3 +145,20 @@ class TestClassInlineSuppressions(TestBaseClass):
                           'oelint.vars.doublemodify', 1)
         self.check_for_id(self._create_args(input_),
                           'oelint.vars.overrideappend', 1)
+
+    @pytest.mark.parametrize('input_',
+                             [
+                                 {
+                                     'oelint adv-test.bb':
+                                     '''
+                                     # nooelint: oelint.var.badimagefeature.allow-empty-password,,oelint.var.badimagefeature.allow-root-login,oelint.var.badimagefeature.empty-root-password
+                                     IMAGE_FEATURES:append = " \
+                                        allow-empty-password allow-root-login empty-root-password \
+                                     "
+                                     ''',
+                                 },
+                             ],
+                             )
+    def test_inlinesuppressions_remove_empty(self, input_):
+        self.check_for_id(self._create_args(input_),
+                          'oelint.var.badimagefeature', 0)


### PR DESCRIPTION
- allow '-' in id
- rewrite filtering to allow multiple items to be mapped better to the workflow

Closes #677

# Pull request checklist

## Bugfix

- [x] A testcase was added to test the behavior

