### PR TITLE
inline-suppressions: allow comments after ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,16 +458,17 @@ You can find an example file [here](docs/.oelint.cfg.example)
 You can suppress one or more checks on a line by line basis
 
 ```bitbake
-# nooelint: <id>[,<id>,...]
+# nooelint: <id>[,<id>,...][ comment]
 ```
 
 suppresses all the specified IDs for the next line.
 Multiple IDs can be separated by commas.
+You can add a comment after the ids and separated by at least a single space.
 
 ### Example
 
 ```bitbake
-# nooelint: oelint.vars.insaneskip
+# nooelint: oelint.vars.insaneskip - this is an acceptable risk here
 INSANE_SKIP:${PN} = "foo"
 ```
 

--- a/tests/test_class_oelint_inlinesupp.py
+++ b/tests/test_class_oelint_inlinesupp.py
@@ -12,14 +12,14 @@ class TestClassOelintNAInlineSuppression(TestBaseClass):
                                  {
                                      'oelint_adv_test.bb':
                                      '''
-                                     # nooelint: foo.bar.baz
+                                     # nooelint: oelint.var.badimagefeature
                                      A = "2"
                                      ''',
                                  },
                                  {
                                      'oelint_adv_test.bb':
                                      '''
-                                     # nooelint: oelint.vars.mispell, foo.bar.baz
+                                     # nooelint: oelint.vars.mispell, oelint.var.badimagefeature
                                      SRR_URI = "2"
                                      ''',
                                  },

--- a/tests/test_inlinesuppressions.py
+++ b/tests/test_inlinesuppressions.py
@@ -162,3 +162,20 @@ class TestClassInlineSuppressions(TestBaseClass):
     def test_inlinesuppressions_remove_empty(self, input_):
         self.check_for_id(self._create_args(input_),
                           'oelint.var.badimagefeature', 0)
+
+    @pytest.mark.parametrize('input_',
+                             [
+                                 {
+                                     'oelint adv-test.bb':
+                                     '''
+                                     # nooelint: oelint.var.badimagefeature.allow-empty-password - this is a comment
+                                     IMAGE_FEATURES:append = " \
+                                        allow-empty-password \
+                                     "
+                                     ''',
+                                 },
+                             ],
+                             )
+    def test_inlinesuppressions_with_comment(self, input_):
+        self.check_for_id(self._create_args(input_),
+                          'oelint.var.badimagefeature', 0)


### PR DESCRIPTION
filter out any words that are not part of the
known IDs list and treat them as comments.
Like this further explanations can be added by the user

Closes #679

# Pull request checklist

## Bugfix

- [x] A testcase was added to test the behavior

