### PR TITLE
core: fix config file list handling

### DIFF
--- a/oelint_adv/core.py
+++ b/oelint_adv/core.py
@@ -30,6 +30,8 @@ class TypeSafeAppendAction(argparse.Action):
         if not isinstance(values, str):
             return  # pragma: no cover
         items = getattr(namespace, self.dest) or []
+        if not isinstance(items, list):
+            items = [x.strip() for x in items.split() if x.strip()]
         items.extend(RegexRpl.split(r'\s+|\t+|\n+', values.strip('"').strip("'")))
         setattr(namespace, self.dest, items)
 


### PR DESCRIPTION
if a config file is used and a statement is
used via CLI, the config parts need to be turned into a list

Closes #681

# Pull request checklist

## Bugfix

- [x] A testcase was added to test the behavior
