### PR TITLE
ci/bump-vars: pin to ubuntu 22.04

### DIFF
--- a/.github/workflows/knownvar_bump.yml
+++ b/.github/workflows/knownvar_bump.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   bumpvar:
     name: "Bump known vars"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     permissions:
       contents: write


### PR DESCRIPTION
to work around the issues of bitbake with ubuntu 24.04
