### PR TITLE
rules/misspell: ignore entries starting with '_'

### DIFF
--- a/oelint_adv/rule_base/rule_var_misspell.py
+++ b/oelint_adv/rule_base/rule_var_misspell.py
@@ -38,6 +38,8 @@ class VarMisspell(Rule):
         for i in items:
             if isinstance(i, Variable):
                 _cleanvarname = i.VarName
+                if _cleanvarname.startswith('_'):
+                    continue
                 if _cleanvarname in CONSTANTS.VariablesKnown:
                     continue
                 if _cleanvarname in _extras:
@@ -47,6 +49,8 @@ class VarMisspell(Rule):
                         _cleanvarname = ''.join(_cleanvarname.rsplit(pkg, 1))  # pragma: no cover
             else:
                 _cleanvarname = i.VarName
+                if _cleanvarname.startswith('_'):
+                    continue
                 if _cleanvarname in _taskname:
                     continue
                 if _cleanvarname in CONSTANTS.VariablesKnown:

--- a/tests/test_class_oelint_vars_misspell.py
+++ b/tests/test_class_oelint_vars_misspell.py
@@ -53,6 +53,10 @@ class TestClassOelintVarsMispell(TestBaseClass):
                                  },
                                  {
                                      'oelint_adv_test.bb':
+                                     '_SECRETVAR = "1"',
+                                 },
+                                 {
+                                     'oelint_adv_test.bb':
                                      '''
                                      PACKAGECONFIG_A = "a"
                                      PACKAGECONFIG_B = "c"
@@ -110,6 +114,10 @@ class TestClassOelintVarsMispell(TestBaseClass):
                                  },
                                  {
                                      'oelint_adv_test.bb':
+                                     '_do_secret[prefuncs] += "foo"',
+                                 },
+                                 {
+                                     'oelint_adv_test.bb':
                                      '''
                                      dskfdsfkjfhsjkfsdjfkj = "1"
                                      ''',
@@ -133,6 +141,10 @@ class TestClassOelintVarsMispell(TestBaseClass):
                                      PACKAGES += "${PN}-foo"
                                      INITSCRIPT_PARAMS_${PN}-foo = "bar"
                                      ''',
+                                 },
+                                 {
+                                     'oelint_adv_test.bb':
+                                     '_SECRETVAR = "1"',
                                  },
                              ],
                              )


### PR DESCRIPTION
those are meant to be private/hidden, so they don't have to be checked. Also they are not exposed in the layer vars generation, leading to false positives

Closes #719

# Pull request checklist

## Bugfix

- [x] A testcase was added to test the behavior

## New feature

- [ ] A testcase was added to test the behavior
- [ ] ``wiki-creator.py`` was run and a new wiki document was filled with information
- [ ] New functions are documented with docstrings
- [ ] No debug code is left
- [ ] README.md was updated to reflect the changes (check even if n.a.)
