### PR TITLE
Fix typo 'licensesdpx' to 'licensespdx' for SPDX license rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ Rules marked with **[I]** need to be activated through [a rule file](#defining-a
 * [oelint.vars.inconspaces](https://github.com/priv-kweihmann/oelint-adv/blob/master/docs/wiki/oelint.vars.inconspaces.md) - Inconsistent use of spaces on append operation
 * [oelint.vars.insaneskip](https://github.com/priv-kweihmann/oelint-adv/blob/master/docs/wiki/oelint.vars.insaneskip.md) - INSANE_SKIP should be avoided at any cost
 * [oelint.vars.layerconf](https://github.com/priv-kweihmann/oelint-adv/blob/master/docs/wiki/oelint.vars.layerconf.md) - Only selected variables should be set as part of a layer.conf
-* [oelint.vars.licensesdpx](https://github.com/priv-kweihmann/oelint-adv/blob/master/docs/wiki/oelint.vars.licensesdpx.md) - Check for correct SPDX syntax in licenses
+* [oelint.vars.licensespdx](https://github.com/priv-kweihmann/oelint-adv/blob/master/docs/wiki/oelint.vars.licensespdx.md) - Check for correct SPDX syntax in licenses
 * [oelint.vars.licfileprefix](https://github.com/priv-kweihmann/oelint-adv/blob/master/docs/wiki/oelint.vars.licfileprefix.md) - Unnecessary prefix to LIC_FILES_CHKSUM detected **[F]**
 * [oelint.vars.listappend](https://github.com/priv-kweihmann/oelint-adv/blob/master/docs/wiki/oelint.vars.listappend.md) - Proper append/prepend to lists **[F]**
 * [oelint.vars.machineconf](https://github.com/priv-kweihmann/oelint-adv/blob/master/docs/wiki/oelint.vars.machineconf.md) - Distro and image variables should not be set as part of a machine config **[S]**

--- a/docs/wiki/oelint.vars.licensesdpx.md
+++ b/docs/wiki/oelint.vars.licensesdpx.md
@@ -1,4 +1,4 @@
-# oelint.vars.licensesdpx
+# oelint.vars.licensespdx
 
 severity: warning
 

--- a/oelint_adv/rule_base/rule_var_license_spdx.py
+++ b/oelint_adv/rule_base/rule_var_license_spdx.py
@@ -6,9 +6,9 @@ from oelint_parser.cls_stash import Stash
 from oelint_adv.cls_rule import Rule
 
 
-class LicenseSDPX(Rule):
+class LicenseSPDX(Rule):
     def __init__(self) -> None:
-        super().__init__(id='oelint.vars.licensesdpx',
+        super().__init__(id='oelint.vars.licensespdx',
                          severity='warning',
                          message='LICENSE is not a valid OpenEmbedded SPDX expression')
 

--- a/tests/test_class_oelint_var_licensespdx.py
+++ b/tests/test_class_oelint_var_licensespdx.py
@@ -5,7 +5,7 @@ from .base import TestBaseClass
 
 class TestClassOelintVarLicenseSPDX(TestBaseClass):
 
-    @pytest.mark.parametrize('id_', ['oelint.vars.licensesdpx'])
+    @pytest.mark.parametrize('id_', ['oelint.vars.licensespdx'])
     @pytest.mark.parametrize('occurrence', [1])
     @pytest.mark.parametrize('input_',
                              [
@@ -26,7 +26,7 @@ class TestClassOelintVarLicenseSPDX(TestBaseClass):
     def test_bad(self, input_, id_, occurrence):
         self.check_for_id(self._create_args(input_), id_, occurrence)
 
-    @pytest.mark.parametrize('id_', ['oelint.var.licensesdpx'])
+    @pytest.mark.parametrize('id_', ['oelint.var.licensespdx'])
     @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('input_',
                              [


### PR DESCRIPTION
- Correct all occurrences of 'licensesdpx' to 'licensespdx' in rule   IDs, documentation, and tests
 - Update README, wiki, rule class, and test parameterization to use the correct SPDX spelling

# Pull request checklist

## Bugfix

- [x] A testcase was added to test the behavior

## New feature

- [x] A testcase was added to test the behavior
- [x] ``wiki-creator.py`` was run and a new wiki document was filled with information
- [x] New functions are documented with docstrings
- [x] No debug code is left
- [x] README.md was updated to reflect the changes (check even if n.a.)
