### PR TITLE
oelint.vars.srcurichecksum: warn about md5sum

### DIFF
--- a/docs/wiki/oelint.vars.srcurichecksum.md
+++ b/docs/wiki/oelint.vars.srcurichecksum.md
@@ -1,6 +1,6 @@
 # oelint.vars.srcurichecksum
 
-severity: error
+severity: error|warning
 
 ## Example
 
@@ -14,6 +14,13 @@ or
 
 ```
 SRC_URI += "ftp://foo"
+```
+
+or
+
+```
+SRC_URI += "ftp://foo"
+SRC_URI[md5sum] = "d8e8fca2dc0f896fd7cb4cb0031ba249"
 ```
 
 ## Why is this bad?
@@ -34,3 +41,5 @@ or
 SRC_URI += "ftp://foo"
 SRC_URI[sha256sum] = "4355a46b19d348dc2f57c046f8ef63d4538ebb936000f3c9ee954a27460dd865"
 ```
+
+or in case of ``md5sum`` replace the line by a proper ``sha256sum``

--- a/oelint_adv/rule_base/rule_var_src_uri_checksum.py
+++ b/oelint_adv/rule_base/rule_var_src_uri_checksum.py
@@ -28,6 +28,9 @@ class VarSRCUriChecksum(Rule):
                         sha256sum.append("")
                     else:
                         sha256sum.append(i.Flag.rsplit(".", 1)[0])
+                if i.Flag.endswith("md5sum") and i.VarName in ['SRC_URI']:
+                    res += self.finding(i.Origin, i.InFileLine, "md5sum is deprecated. It can be removed.",
+                                        severity_override="warning")
             else:
                 lines = [y.strip('"') for y in i.get_items() if y and y != INLINE_BLOCK]
                 for index, value in enumerate(lines):

--- a/tests/test_class_oelint_vars_srcurichecksum.py
+++ b/tests/test_class_oelint_vars_srcurichecksum.py
@@ -19,13 +19,6 @@ class TestClassOelintVarsSRCURICHECKSUM(TestBaseClass):
                                      'oelint_adv_test.bb':
                                      '''
                                      SRC_URI += "ftp://foo;name=f3"
-                                     SRC_URI[f1.md5sum] = "a"
-                                     ''',
-                                 },
-                                 {
-                                     'oelint_adv_test.bb':
-                                     '''
-                                     SRC_URI += "ftp://foo;name=f3"
                                      SRC_URI += "ftp://foo;name=f2"
                                      SRC_URI[f3.sha256sum] = "a"
                                      ''',
@@ -34,6 +27,22 @@ class TestClassOelintVarsSRCURICHECKSUM(TestBaseClass):
                                      'oelint_adv_test.bb':
                                      '''
                                      SRC_URI += "ftp://foo"
+                                     ''',
+                                 },
+                                 {
+                                     'oelint_adv_test.bb':
+                                     '''
+                                     SRC_URI += "ftp://foo"
+                                     SRC_URI[sha256sum] = "a"
+                                     SRC_URI[md5sum] = "a"
+                                     ''',
+                                 },
+                                 {
+                                     'oelint_adv_test.bb':
+                                     '''
+                                     SRC_URI += "ftp://foo;name=f3"
+                                     SRC_URI[f3.sha256sum] = "a"
+                                     SRC_URI[f3.md5sum] = "a"
                                      ''',
                                  },
                              ],
@@ -68,17 +77,11 @@ class TestClassOelintVarsSRCURICHECKSUM(TestBaseClass):
                                      SRC_URI += "npm://foo"
                                      SRC_URI += "svn://foo"
                                      SRC_URI += "az://foo;name=f6"
-                                     SRC_URI[f1.md5sum] = "a"
                                      SRC_URI[f1.sha256sum] = "a"
-                                     SRC_URI[f2.md5sum] = "a"
                                      SRC_URI[f2.sha256sum] = "a"
-                                     SRC_URI[f3.md5sum] = "a"
                                      SRC_URI[f3.sha256sum] = "a"
-                                     SRC_URI[f4.md5sum] = "a"
                                      SRC_URI[f4.sha256sum] = "a"
-                                     SRC_URI[f5.md5sum] = "a"
                                      SRC_URI[f5.sha256sum] = "a"
-                                     SRC_URI[f6.md5sum] = "a"
                                      SRC_URI[f6.sha256sum] = "a"
                                      ''',
                                  },
@@ -112,9 +115,7 @@ class TestClassOelintVarsSRCURICHECKSUM(TestBaseClass):
                                      '''
                                      SRC_URI += "ftp://foo \\
                                                  ftp://foo;name=f1"
-                                     SRC_URI[md5sum] = "a"
                                      SRC_URI[sha256sum] = "a"
-                                     SRC_URI[f1.md5sum] = "a"
                                      SRC_URI[f1.sha256sum] = "a"
                                      ''',
                                  },
@@ -129,14 +130,12 @@ class TestClassOelintVarsSRCURICHECKSUM(TestBaseClass):
                                      '''
                                      SRC_URI += "http://foo;name=f1"
                                      SRC_URI[f1.sha256sum] = "a"
-                                     SRC_URI[f1.md5sum] = "a"
                                      ''',
                                  },
                                  {
                                      'oelint_adv_test.bb':
                                      '''
                                      SRC_URI += "ftp://foo"
-                                     SRC_URI[md5sum] = "a"
                                      SRC_URI[sha256sum] = "a"
                                      ''',
                                  },
@@ -152,6 +151,12 @@ class TestClassOelintVarsSRCURICHECKSUM(TestBaseClass):
                                      '''
                                      SRC_URI += "ftp://foo"
                                      SRC_URI[sha256sum] = "a"
+                                     ''',
+                                 },
+                                 {
+                                     'oelint_adv_test.bb':
+                                     '''
+                                     CUSTOM_VAR[md5sum] = "a"
                                      ''',
                                  },
                              ],


### PR DESCRIPTION
as this is long time deprecated now

Closes #757

# Pull request checklist

## Bugfix

- [ ] A testcase was added to test the behavior

## New feature

- [x] A testcase was added to test the behavior
- [x] ``wiki-creator.py`` was run and a new wiki document was filled with information
- [x] New functions are documented with docstrings
- [x] No debug code is left
- [x] README.md was updated to reflect the changes (check even if n.a.)
