### PR TITLE
core: fix grouping

### DIFF
--- a/oelint_adv/core.py
+++ b/oelint_adv/core.py
@@ -97,8 +97,8 @@ def group_files(files: Iterable[str], mode: str) -> List[Tuple[List[str], List[s
             continue
         _match = False
         for _, v in res.items():
-            _needle = '.*/' + os.path.basename(_filename).replace('%', '.*')
-            if any(RegexRpl.match(_needle, x) for x in v):
+            _needle = '^.*/' + re.escape(os.path.basename(_filename)).replace('%', '.*') + '.bb$'
+            if any(RegexRpl.match(_needle, x, re.MULTILINE) for x in v):
                 v.add(f)
                 _match = True
         if not _match:

--- a/tests/test_grouping.py
+++ b/tests/test_grouping.py
@@ -76,6 +76,22 @@ class TestGrouping(TestBaseClass):
         assert ['test1_1.0.bb'] in res
         assert ['test1_2.%.bbappend'] in res
 
+    def test_fast_bb_bbappend_full_filename(self):
+        from oelint_adv.core import group_files
+
+        input_ = {
+            'test1.bb': '',
+            'test1-debug.bb': '',
+            'test1.bbappend': '',
+            'test1-debug.bbappend': '',
+        }
+
+        args = self._create_args(input_)
+        res = [self.__flatten_file_names(x[0]) for x in group_files(args.files, args.mode)]
+
+        assert ['test1.bb', 'test1.bbappend'] in res
+        assert ['test1-debug.bb', 'test1-debug.bbappend'] in res
+
     def test_fast_layer_conf(self):
         from oelint_adv.core import group_files
 


### PR DESCRIPTION
by taking the full filename into account.
This will prevent version less files, like images, being grouped together, when their common file prefix is the same

Closes #766

# Pull request checklist

## Bugfix

- [x] A testcase was added to test the behavior

## New feature

- [ ] A testcase was added to test the behavior
- [ ] ``wiki-creator.py`` was run and a new wiki document was filled with information
- [ ] New functions are documented with docstrings
- [ ] No debug code is left
- [ ] README.md was updated to reflect the changes (check even if n.a.)
