### PR TITLE
core: fix inline supp in multiline comments

### DIFF
--- a/oelint_adv/core.py
+++ b/oelint_adv/core.py
@@ -219,13 +219,14 @@ def group_run(group: List[Tuple],
 
     inline_supp_map = {}
     for item in stash.GetItemsFor(classifier=Comment.CLASSIFIER):
-        for line in item.get_items():
+        for index, line in enumerate(item.get_items()):
             m = re.match(
-                r'^#\s+nooelint:\s+(?P<ids>[A-Za-z0-9\.,_\s-]*)', line)
+                r'^#\s+nooelint:\s+(?P<ids>[A-Za-z0-9\.,_\s-]*)', line, re.MULTILINE)
             if m:
                 if item.Origin not in inline_supp_map:  # pragma: no cover
                     inline_supp_map[item.Origin] = {}
-                inline_supp_map[item.Origin][item.InFileLine] = [
+                pos = item.InFileLine + index
+                inline_supp_map[item.Origin][pos] = [
                     x.strip() for x in re.split(r',|\s+', m.group('ids')) if x]
 
     state.inline_suppressions = {**state.inline_suppressions, **inline_supp_map}

--- a/tests/test_inlinesuppressions.py
+++ b/tests/test_inlinesuppressions.py
@@ -35,6 +35,15 @@ class TestClassInlineSuppressions(TestBaseClass):
                                      # nooelint: oelint.vars.insaneskip - some explanation
                                      INSANE_SKIP_${PN} = "foo"
                                      ''',
+                                 },
+                                 {
+                                     'oelint adv-test.bb':
+                                     '''
+                                     # comment preamble
+                                     # with a lot more information
+                                     # nooelint: oelint.vars.insaneskip
+                                     INSANE_SKIP_${PN} = "foo"
+                                     ''',
                                  }
                              ],
                              )


### PR DESCRIPTION
as the latest parser will wrap comments into
blocks we need to adjust the extraction of
nooelint marker accordingly

Closes #792

# Pull request checklist

## Bugfix

- [x] A testcase was added to test the behavior

