### PR TITLE
Fix oelint.spaces.lineend removing empty lines in functions

### DIFF
--- a/oelint_adv/rule_base/rule_nospace_line_end.py
+++ b/oelint_adv/rule_base/rule_nospace_line_end.py
@@ -33,7 +33,7 @@ class NoSpaceTrailingRule(Rule):
     def fix(self, _file: str, stash: Stash) -> List[str]:
         res = []
         for i in self.__getMatches(_file, stash):
-            i[0].RealRaw = RegexRpl.sub(r'\s+\n', '\n', i[0].RealRaw)
-            i[0].Raw = RegexRpl.sub(r'\s+\n', '\n', i[0].Raw)
+            i[0].RealRaw = RegexRpl.sub(r"[^\S\r\n]+\n", "\n", i[0].RealRaw)
+            i[0].Raw = RegexRpl.sub(r"[^\S\r\n]+\n", "\n", i[0].Raw)
             res.append(_file)
         return res

--- a/tests/test_class_oelint_spaces_lineend.py
+++ b/tests/test_class_oelint_spaces_lineend.py
@@ -85,3 +85,21 @@ class TestClassOelintSpacesLineEnd(TestBaseClass):
                              )
     def test_good(self, input_, id_, occurrence):
         self.check_for_id(self._create_args(input_), id_, occurrence)
+
+    @pytest.mark.parametrize("id_", ["oelint.spaces.lineend"])
+    @pytest.mark.parametrize(
+        "input_",
+        [
+            (
+                {
+                    "oelint_adv_test.bb": 'do_compile() {\n\n    echo example \n}\n',
+                },
+                'do_compile() {\n\n    echo example\n}\n',
+            ),
+        ],
+    )
+    def test_fix_output(self, input_, id_):
+        args = self._create_args_fix(input_[0])
+        self.fix_and_check(args, id_)
+        with open(args.files[0]) as f:
+            assert f.read() == input_[1]


### PR DESCRIPTION
# Pull request checklist

## Bugfix

Currently the `oelint.spaces.lineend` rule will remove empty lines in functions which contain any trailing white space. This seems to be due to the regex matching multiple lines. To fix this I simply updated the logic to prevent newlines being matched in the regex.

For example, the following file:
```
do_compile() {


    echo example<space>
}
```

is currently incorrectly fixed to:
```
do_compile() {
    echo example
}
```

- [x] A testcase was added to test the behavior

