### PR TITLE
rules: fix false positive GROUPMEMS_PARAM warning

### DIFF
--- a/oelint_adv/rule_base/rule_var_override_append.py
+++ b/oelint_adv/rule_base/rule_var_override_append.py
@@ -21,6 +21,7 @@ class VarOverrideAppend(Rule):
             'DESCRIPTION',
             'FILES',
             'GROUPADD_PARAM',
+            'GROUPMEMS_PARAM',
             'INITSCRIPT_NAME',
             'INITSCRIPT_PARAMS',
             'INSANE_SKIP',


### PR DESCRIPTION
Usage of `GROUPMEMS_PARAM:${PN}:append` issues a false positive warning : 
`warning:oelint.vars.overrideappend:This creates an empty scope which is then appended. It should be append:${PN} instead [branch:true]`

Similarly to `GROUPADD_PARAM`, `GROUPMEMS_PARAM` applies to packages. This means `GROUPMEMS_PARAM:${PN}:append` must be considered as a valid syntax (see [1])

[1]: https://docs.yoctoproject.org/5.2.4/ref-manual/variables.html#term-GROUPMEMS_PARAM

# Pull request checklist

## Bugfix

- [ ] A testcase was added to test the behavior

## New feature

- [ ] A testcase was added to test the behavior
- [ ] ``wiki-creator.py`` was run and a new wiki document was filled with information
- [ ] New functions are documented with docstrings
- [ ] No debug code is left
- [ ] README.md was updated to reflect the changes (check even if n.a.)
