### PR TITLE
docs: Update Upstream-Status related links

### DIFF
--- a/docs/wiki/oelint.file.inactiveupstreamdetails.md
+++ b/docs/wiki/oelint.file.inactiveupstreamdetails.md
@@ -19,7 +19,7 @@ Upstream-Status: Inactive-Upstream [1234]
 ## Why is this bad?
 
 ``Inactive-Upstream`` shall name a timestamp when the last activity was seen upstream,
-see former [OpenEmbedded contribution guide](https://www.openembedded.org/index.php?title=Commit_Patch_Message_Guidelines&oldid=10935)
+see former [Yocto Upstream-Status guide](https://docs.yoctoproject.org/contributor-guide/recipe-style-guide.html#patch-upstream-status)
 
 ## Ways to fix it
 

--- a/docs/wiki/oelint.file.inappropriatemsg.md
+++ b/docs/wiki/oelint.file.inappropriatemsg.md
@@ -26,7 +26,7 @@ Upstream-Status: Inappropriate (configuration)
 
 ``Inappropriate`` will create technical debt, as the will never be merged upstream,
 so labelling why this patch is needed is essential for tracking.
-See [OpenEmbedded contribution guide](https://www.openembedded.org/index.php?title=Commit_Patch_Message_Guidelines&oldid=10935)
+See [Yocto Upstream-Status guide](https://docs.yoctoproject.org/contributor-guide/recipe-style-guide.html#patch-upstream-status)
 
 ## Ways to fix it
 

--- a/docs/wiki/oelint.file.patchsignedoff.md
+++ b/docs/wiki/oelint.file.patchsignedoff.md
@@ -15,7 +15,7 @@ is missing
 ## Why is this bad?
 
 Every upstreamable patch should have a ``Signed-off-by`` line.
-See [OpenEmbedded contribution guide](https://www.openembedded.org/index.php?title=Commit_Patch_Message_Guidelines&oldid=10935)
+See [Yocto Upstream-Status guide](https://docs.yoctoproject.org/contributor-guide/recipe-style-guide.html#patch-upstream-status)
 
 ## Ways to fix it
 

--- a/docs/wiki/oelint.file.upstreamstatus.md
+++ b/docs/wiki/oelint.file.upstreamstatus.md
@@ -15,7 +15,7 @@ is missing or not classified properly
 ## Why is this bad?
 
 Every patch should have a ``Upstream-Status`` line.
-See [OpenEmbedded contribution guide](https://www.openembedded.org/index.php?title=Commit_Patch_Message_Guidelines&oldid=10935)
+See [Yocto Upstream-Status guide](https://docs.yoctoproject.org/contributor-guide/recipe-style-guide.html#patch-upstream-status)
 
 ## Ways to fix it
 


### PR DESCRIPTION
The current links are broken. Fix this by pointing to the current
Upstream-Status section in the Recipe Style Guide page of
Yocto Project documentation.

# Pull request checklist

## Bugfix

- [ ] A testcase was added to test the behavior

## New feature

- [ ] A testcase was added to test the behavior
- [ ] ``wiki-creator.py`` was run and a new wiki document was filled with information
- [ ] New functions are documented with docstrings
- [ ] No debug code is left
- [ ] README.md was updated to reflect the changes (check even if n.a.)
