### PR TITLE
srcurioptions: allow patch-specific options

### DIFF
--- a/oelint_adv/rule_base/rule_var_src_uri.py
+++ b/oelint_adv/rule_base/rule_var_src_uri.py
@@ -24,6 +24,17 @@ class VarSRCUriOptions(Rule):
             'unpack',
             'user',
         ]
+        self._patch_options = [
+            'maxdate',
+            'maxrev',
+            'maxver',
+            'mindate',
+            'minrev',
+            'minver',
+            'notrev',
+            'pname',
+            'pnum',
+        ]
         self._valid_options = {
             'az': [
                 'md5sum',
@@ -206,12 +217,23 @@ class VarSRCUriOptions(Rule):
                                 "Fetcher '{a}' is not known".format(a=_url['scheme']),
                                 blockoffset=item.InFileLine)
         else:
+            # file:// fetcher applies patch handling for .patch/.diff files or
+            # when apply= is set to a truthy value (case-insensitive)
+            _is_patch_file = _url['scheme'] == 'file' and (
+                any(_url.get('src', '').endswith(ext) for ext in ('.patch', '.diff')) or
+                _url['options'].get('apply', '').lower() in ('1', 'yes', 'true')
+            )
             for k, v in _url['options'].items():
                 if _url['scheme'] not in self._valid_options:
                     continue  # pragma: no cover
                 if k == 'type' and v == 'kmeta':
                     continue  # linux-yocto uses this option to indicate kernel metadata sources
-                if k not in self._valid_options[_url['scheme']] + self._general_options:
+                _allowed = (
+                    self._valid_options[_url['scheme']] +
+                    self._general_options +
+                    (self._patch_options if _is_patch_file else [])
+                )
+                if k not in _allowed:
                     res += self.finding(item.Origin, item.InFileLine + _index,
                                         "Option '{a}' is not known with this fetcher type".format(a=k),
                                         blockoffset=item.InFileLine)

--- a/tests/test_class_oelint_vars_srcurioptions.py
+++ b/tests/test_class_oelint_vars_srcurioptions.py
@@ -45,6 +45,18 @@ OPTIONS_AVAILABLE = [
     'vob',
     'unknownoperation',
 ]
+# Options valid only for patch files (file:// with .patch/.diff extension or apply= set)
+PATCH_OPTIONS = [
+    'maxdate',
+    'maxrev',
+    'maxver',
+    'mindate',
+    'minrev',
+    'minver',
+    'notrev',
+    'pname',
+    'pnum',
+]
 OPTION_MAPPING = {
     'az': [
         'apply',
@@ -982,4 +994,50 @@ class TestClassOelintVarsSRCURIOptions(TestBaseClass):
                              ],
                              )
     def test_type_kmeta_allowed(self, input_, id_, occurrence):
+        self.check_for_id(self._create_args(input_), id_, occurrence)
+
+    @pytest.mark.parametrize('id_', ['oelint.vars.srcurioptions'])
+    @pytest.mark.parametrize('occurrence', [0])
+    @pytest.mark.parametrize('option', PATCH_OPTIONS)
+    @pytest.mark.parametrize('extension', ['.patch', '.diff'])
+    def test_good_file_patch_options(self, id_, occurrence, option, extension):
+        input_ = {
+            'oelint_adv_test.bb': 'SRC_URI += "file://foo{ext};{opt}=1"'.format(ext=extension, opt=option),
+        }
+        self.check_for_id(self._create_args(input_), id_, occurrence)
+
+    @pytest.mark.parametrize('id_', ['oelint.vars.srcurioptions'])
+    @pytest.mark.parametrize('occurrence', [0])
+    @pytest.mark.parametrize('option', PATCH_OPTIONS)
+    def test_good_file_apply_patch_options(self, id_, occurrence, option):
+        input_ = {
+            'oelint_adv_test.bb': 'SRC_URI += "file://foo.tar.gz;apply=1;{opt}=1"'.format(opt=option),
+        }
+        self.check_for_id(self._create_args(input_), id_, occurrence)
+
+    @pytest.mark.parametrize('id_', ['oelint.vars.srcurioptions'])
+    @pytest.mark.parametrize('occurrence', [1])
+    @pytest.mark.parametrize('option', PATCH_OPTIONS)
+    def test_bad_file_non_patch_patch_options(self, id_, occurrence, option):
+        input_ = {
+            'oelint_adv_test.bb': 'SRC_URI += "file://foo.tar.gz;{opt}=1"'.format(opt=option),
+        }
+        self.check_for_id(self._create_args(input_), id_, occurrence)
+
+    @pytest.mark.parametrize('id_', ['oelint.vars.srcurioptions'])
+    @pytest.mark.parametrize('occurrence', [1])
+    @pytest.mark.parametrize('option', PATCH_OPTIONS)
+    def test_bad_non_file_patch_options(self, id_, occurrence, option):
+        input_ = {
+            'oelint_adv_test.bb': 'SRC_URI += "https://example.com/foo.patch;{opt}=1"'.format(opt=option),
+        }
+        self.check_for_id(self._create_args(input_), id_, occurrence)
+
+    @pytest.mark.parametrize('id_', ['oelint.vars.srcurioptions'])
+    @pytest.mark.parametrize('occurrence', [1])
+    @pytest.mark.parametrize('option', PATCH_OPTIONS)
+    def test_bad_git_patch_options(self, id_, occurrence, option):
+        input_ = {
+            'oelint_adv_test.bb': 'SRC_URI += "git://example.com/foo.git;protocol=https;branch=main;{opt}=1"'.format(opt=option),
+        }
         self.check_for_id(self._create_args(input_), id_, occurrence)


### PR DESCRIPTION
Bitbake accepts additional options for patches, (maxdate, maxrev, maxver, mindate, minrev, minver, notrev, pname, pnum) [1], that are valid when a file:// entry is being applied as a patch.

Detect patch files by checking if the filename ends in .patch/.diff, or if apply= is set true. Only allow the patch-specific options in those cases, reject them for regular file:// entries.

Add tests covering:
- patch options accepted for .patch/.diff files (file://)
- patch options accepted when apply=1 is set (file://)
- patch options rejected for non-patch file:// entries

1 - https://git.openembedded.org/openembedded-core/tree/meta/lib/oe/patch.py?id=a64b4f39724c13de3cc5098dbcbcb4fb8a40dbac#n962

# Pull request checklist

## Bugfix

- [ ] A testcase was added to test the behavior

## New feature

- [ ] A testcase was added to test the behavior
- [ ] ``wiki-creator.py`` was run and a new wiki document was filled with information
- [ ] New functions are documented with docstrings
- [ ] No debug code is left
- [ ] README.md was updated to reflect the changes (check even if n.a.)
