### PR TITLE
improperinherit: skip in defer with variables

### DIFF
--- a/oelint_adv/rule_base/rule_vars_improperinherit.py
+++ b/oelint_adv/rule_base/rule_vars_improperinherit.py
@@ -16,8 +16,11 @@ class VarImproperInherit(Rule):
 
     def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
         res = []
-        items = stash.GetItemsFor(filename=_file, classifier=Inherit.CLASSIFIER)
+        items: list[Inherit] = stash.GetItemsFor(
+            filename=_file, classifier=Inherit.CLASSIFIER)
         for i in items:
+            if i.Statement in ['inherit_defer'] and '${' in i.Class:
+                continue
             for subi in [stash.ExpandTerm(_file, x) for x in i.get_items() if x and x != INLINE_BLOCK]:
                 if not RegexRpl.match(r'^[A-Za-z0-9_.-]+$', subi):
                     res += self.finding(i.Origin, i.InFileLine,

--- a/tests/test_class_oelint_var_improperinherit.py
+++ b/tests/test_class_oelint_var_improperinherit.py
@@ -21,6 +21,18 @@ class TestClassOelintVarImproperInherit(TestBaseClass):
                                      'oelint_adv_test.bb':
                                      'inherit ghi>bbclass',
                                  },
+                                 {
+                                     'oelint_adv_test.bb':
+                                     'inherit_defer abc/abc abc',
+                                 },
+                                 {
+                                     'oelint_adv_test.bb':
+                                     'inherit_defer def~AAAA',
+                                 },
+                                 {
+                                     'oelint_adv_test.bb':
+                                     'inherit_defer ghi>bbclass',
+                                 },
                              ],
                              )
     def test_bad(self, input_, id_, occurrence):
@@ -52,6 +64,14 @@ class TestClassOelintVarImproperInherit(TestBaseClass):
                                      XORGBUILDCLASS ??= "autotools"
                                      inherit ${XORGBUILDCLASS} pkgconfig features_check
                                      ''',
+                                 },
+                                 {
+                                     'oelint_adv_test.bb':
+                                     'inherit_defer native',
+                                 },
+                                 {
+                                     'oelint_adv_test.bb':
+                                     'inherit_defer ${A}',
                                  },
                              ],
                              )


### PR DESCRIPTION
as variable expansion might bring back no
results, leading to a false positive

Closes #883

# Pull request checklist

## Bugfix

- [x] A testcase was added to test the behavior

## New feature

- [ ] A testcase was added to test the behavior
- [ ] ``wiki-creator.py`` was run and a new wiki document was filled with information
- [ ] New functions are documented with docstrings
- [ ] No debug code is left
- [ ] README.md was updated to reflect the changes (check even if n.a.)
