### PR TITLE
oelint.vars.layerconf: fix for old syntax

### DIFF
--- a/oelint_adv/rule_base/rule_vars_layerconf.py
+++ b/oelint_adv/rule_base/rule_vars_layerconf.py
@@ -38,7 +38,7 @@ class VarsLayerConf(Rule):
         for i in items:
             if not fnmatch.fnmatch(i.Origin, '*/layer.conf'):
                 continue
-            if not any(RegexRpl.match(x, i.VarName) for x in self.good):
+            if not any(RegexRpl.match(x, i.VarNameCompleteNoModifiers) for x in self.good):
                 res += self.finding(_file, i.InFileLine,
                                     self.Msg.format(var=i.VarName))
         return res

--- a/tests/test_class_oelint_vars_layerconf.py
+++ b/tests/test_class_oelint_vars_layerconf.py
@@ -50,6 +50,30 @@ class TestClassOelintVarsLayerConf(TestBaseClass):
         'LICENSE_PATH',
     ])
     @pytest.mark.parametrize('operation', ['=', ':=', '.=', '=.', '+=', '=+', ' =+'])
+    def test_good_old_syntax(self, id_, var, operation, occurrence):
+        input_ = {
+            'conf/layer.conf': self.__generate_sample_code(var, operation),
+        }
+        self.check_for_id(self._create_args(
+            input_, ['--release=dunfell']), id_, occurrence)
+
+    @pytest.mark.parametrize('id_', ['oelint.vars.layerconf'])
+    @pytest.mark.parametrize('occurrence', [0])
+    @pytest.mark.parametrize('var', [
+        'BBFILES',
+        'BBFILES_DYNAMIC',
+        'BBFILE_COLLECTIONS',
+        'BBFILE_PATTERN_foo',
+        'BBFILE_PRIORITY_foo',
+        'BBPATH',
+        'HOSTTOOLS_NONFATAL',
+        'LAYERDEPENDS_foo',
+        'LAYERRECOMMENDS_foo',
+        'LAYERSERIES_COMPAT_foo',
+        'LAYERVERSION_foo',
+        'LICENSE_PATH',
+    ])
+    @pytest.mark.parametrize('operation', ['=', ':=', '.=', '=.', '+=', '=+', ' =+'])
     def test_good_non_layer(self, id_, var, operation, occurrence):
         input_ = {
             'oelint-test_1.0.bb': self.__generate_sample_code(var, operation),


### PR DESCRIPTION
as the _ splits the var name into 2 parts
when running with the old syntax,
we need to look at VarNameCompleteNoModifiers
instead.
This removes false positives on e.g. dunfell

# Pull request checklist

## Bugfix

- [x] A testcase was added to test the behavior

## New feature

- [ ] A testcase was added to test the behavior
- [ ] ``wiki-creator.py`` was run and a new wiki document was filled with information
- [ ] New functions are documented with docstrings
- [ ] No debug code is left
- [ ] README.md was updated to reflect the changes (check even if n.a.)
