### PR TITLE
Configurable classifiers for inappropriate upstream-status

### DIFF
--- a/docs/wiki/oelint.file.inappropriatemsg.md
+++ b/docs/wiki/oelint.file.inappropriatemsg.md
@@ -48,3 +48,6 @@ or any other reason in the square brackets from the following list
 - embedded specific
 - no upstream
 - other
+- upstream ticket .*
+
+The valid set of items can be configured through `oelint-inappropriate-status-classifiers` via [Constants](https://github.com/priv-kweihmann/oelint-adv/tree/master/docs/constants.md)

--- a/oelint_adv/data/oelint.json
+++ b/oelint_adv/data/oelint.json
@@ -82,6 +82,22 @@
             "SRC_URI"
         ]
     },
+    "oelint-inappropriate-status-classifiers": [
+        "oe-specific",
+        "OE specific",
+        "oe-core specific",
+        "not author",
+        "native",
+        "licensing",
+        "configuration",
+        "enable feature",
+        "disable feature",
+        "bugfix .*",
+        "embedded specific",
+        "no upstream",
+        "other",
+        "upstream ticket .*"
+    ],
     "oelint-semicolon-vars": [
         "LIC_FILES_CHKSUM",
         "SRC_URI"

--- a/oelint_adv/rule_base/rule_file_patch_inappropriatemsg.py
+++ b/oelint_adv/rule_base/rule_file_patch_inappropriatemsg.py
@@ -4,6 +4,7 @@ from typing import List, Tuple
 import regex  # noqa: I900
 from oelint_parser.cls_item import Variable
 from oelint_parser.cls_stash import Stash
+from oelint_parser.constants import CONSTANTS
 from oelint_parser.rpl_regex import RegexRpl
 
 from oelint_adv.cls_rule import Rule, Classification
@@ -13,7 +14,8 @@ class FilePatchIsUpstreamStatusInAppMsg(Rule):
     def __init__(self):
         super().__init__(id='oelint.file.inappropriatemsg',
                          severity='info',
-                         run_on=[Classification.BBAPPEND, Classification.RECIPE],
+                         run_on=[Classification.BBAPPEND,
+                                 Classification.RECIPE],
                          message="Patch '{FILE}' with Upstream-Status Inappropriate has to have a reasoning appended in [], chosen from {choices}")
 
     def _get_recipe(self, items, path):
@@ -27,21 +29,8 @@ class FilePatchIsUpstreamStatusInAppMsg(Rule):
         _items = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
                                    attribute=Variable.ATTR_VAR, attributeValue='SRC_URI')
 
-        _valid_classifiers = [
-            'oe-specific',
-            'OE specific',
-            'oe-core specific',
-            'not author',
-            'native',
-            'licensing',
-            'configuration',
-            'enable feature',
-            'disable feature',
-            'bugfix .*',
-            'embedded specific',
-            'no upstream',
-            'other',
-        ]
+        _valid_classifiers = CONSTANTS.GetByPath(
+            'oelint-inappropriate-status-classifiers')
 
         _valid_class = {
             'Inappropriate': r'Inappropriate\s+\[({a})\]'.format(a='|'.join(_valid_classifiers)),

--- a/tests/test_class_oelint_file_inappmsg.py
+++ b/tests/test_class_oelint_file_inappmsg.py
@@ -58,6 +58,8 @@ class TestClassOelintFileUpstreamStatusInAppMsg(TestBaseClass):
                                  _generate_input('diff', 'Inappropriate [no upstream]'),
                                  _generate_input('patch', 'Inappropriate [other]'),
                                  _generate_input('diff', 'Inappropriate [other]'),
+                                 _generate_input('patch', 'Inappropriate [upstream ticket https://foo.com/bar]'),
+                                 _generate_input('diff', 'Inappropriate [upstream ticket https://foo.com/bar]'),
                                  {
                                      'oelint_adv-test.bb':
                                      'SRC_URI = "file://test.patch"',
@@ -82,3 +84,24 @@ class TestClassOelintFileUpstreamStatusInAppMsg(TestBaseClass):
                              )
     def test_good(self, input_, id_, occurrence):
         self.check_for_id(self._create_args(input_), id_, occurrence)
+
+    @pytest.mark.parametrize('id_', ['oelint.file.inappropriatemsg'])
+    @pytest.mark.parametrize('occurrence', [0])
+    @pytest.mark.parametrize('input_',
+                             [
+                                 _generate_input('patch', 'Inappropriate [vendor-specific]'),
+                                 _generate_input('diff', 'Inappropriate [vendor-specific]'),
+                             ],
+                             )
+    def test_good_custom_classifier_mod(self, input_, id_, occurrence):
+        _mod_content = '''
+        {
+            "oelint-inappropriate-status-classifiers": [
+                "vendor-specific"
+            ]
+        }
+        '''
+        _extra_opts = [
+            '--constantmods=+{mod}'.format(mod=self._create_tempfile('constmod', _mod_content)),
+        ]
+        self.check_for_id(self._create_args(input_, extraopts=_extra_opts), id_, occurrence)


### PR DESCRIPTION
Allow 'Upstream-Status: Inappropriate' classifiers to be configurable using oeling.json

Adding the newly added 'upstream ticket' to the valid data

# Pull request checklist

## Bugfix

- [ ] A testcase was added to test the behavior

## New feature

- [x] A testcase was added to test the behavior
- [x] ``wiki-creator.py`` was run and a new wiki document was filled with information
- [x] New functions are documented with docstrings
- [x] No debug code is left
- [x] README.md was updated to reflect the changes (check even if n.a.)
