### PR TITLE
Support the gomod fetcher in SRC_URI rules

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,4 +8,4 @@ repos:
     args:
       - --skip=*.lock,tests/test_class_oelint_vars_misspell.py,oelint_adv/data/*
       # Provide a comma separated list of ignored words here:
-      - -L=mispell
+      - -L=mispell,crate

--- a/oelint_adv/rule_base/rule_var_src_uri.py
+++ b/oelint_adv/rule_base/rule_var_src_uri.py
@@ -109,8 +109,10 @@ class VarSRCUriOptions(Rule):
             ],
             'gomod': [
                 'downloadfilename',
+                'md5sum',
                 'mod',
                 'module',
+                'sha256sum',
                 'version',
             ],
             'gomodgit': [

--- a/oelint_adv/rule_base/rule_var_src_uri_domains.py
+++ b/oelint_adv/rule_base/rule_var_src_uri_domains.py
@@ -8,6 +8,11 @@ from oelint_adv.cls_rule import Rule
 
 
 class VarSRCUriOptions(Rule):
+    # Package-manager fetchers reference a dependency manifest, so spanning many
+    # module domains (one entry per Go module, crate, npm package, ...) is
+    # expected and not an indication of a mirroring problem.
+    _package_manager_schemes = {'gomod', 'gomodgit', 'crate', 'npm', 'npmsw'}
+
     def __init__(self) -> None:
         super().__init__(id='oelint.vars.srcuridomains',
                          severity='warning',
@@ -30,7 +35,8 @@ class VarSRCUriOptions(Rule):
                 if u == INLINE_BLOCK:
                     continue
                 _url = stash.GetScrComponents(u)
-                if _url['scheme'] and _url['scheme'] not in ['file']:
+                # 'file' has no remote domain to compare against
+                if _url['scheme'] and _url['scheme'] != 'file' and _url['scheme'] not in self._package_manager_schemes:
                     domain = _url['src'].split('/')[0]
                     if _is_append:
                         _domains[_overrides].add(domain)

--- a/tests/test_class_oelint_vars_srcuridomains.py
+++ b/tests/test_class_oelint_vars_srcuridomains.py
@@ -100,6 +100,14 @@ class TestClassOelintVarsSRCURIdomains(TestBaseClass):
                                      SRC_URI = "git://foo.baz;branch=master;protocol=https"
                                      ''',
                                  },
+                                 {
+                                     'oelint_adv_test.bb':
+                                     '''
+                                     SRC_URI = "git://github.com/foo/bar;branch=main;protocol=https"
+                                     SRC_URI += "gomod://cel.dev/expr;version=v0.25.1;sha256sum=aaa"
+                                     SRC_URI += "crate://crates.io/aho-corasick/0.6.10"
+                                     ''',
+                                 },
                              ],
                              )
     def test_good(self, input_, id_, occurrence):

--- a/tests/test_class_oelint_vars_srcurioptions.py
+++ b/tests/test_class_oelint_vars_srcurioptions.py
@@ -222,9 +222,11 @@ OPTION_MAPPING = {
     ],
     'gomod': [
         'downloadfilename',
+        'md5sum',
         'mod',
         'module',
         'pswd',
+        'sha256sum',
         'user',
         'version',
     ],


### PR DESCRIPTION
Two related false positives fire on recipes that vendor Go modules via the
`gomod://` fetcher (`inherit go-mod go-mod-update-modules`):

**1. `oelint.vars.srcurioptions` — checksum options flagged as unknown**

The gomod fetcher downloads a module zip whose integrity is verified via a
`sha256sum` (and `md5sum` is accepted by the fetch2 checksum machinery as
well). oe-core's `go-mod-update-modules.bbclass` emits a `sha256sum` for every
generated entry, so each line tripped "Option 'sha256sum' is not known with
this fetcher type". Added `md5sum`/`sha256sum` to the gomod option set.

**2. `oelint.vars.srcuridomains` — generated module lists flagged as multi-domain**

A vendored go-mods list contains one `gomod://` entry per module, spanning many
domains (cel.dev, golang.org, google.golang.org, …). These reference a
dependency manifest rather than mirror sources, so the "pulling from different
domains" warning is a false positive. Package-manager fetchers (`gomod`,
`gomodgit`, `crate`, `npm`, `npmsw`) are now skipped when collecting domains.

Both changes have tests; the full suite passes.