### PR TITLE
color: support for NO_COLOR

### DIFF
--- a/oelint_adv/state.py
+++ b/oelint_adv/state.py
@@ -1,3 +1,4 @@
+import os
 from typing import List
 
 from colorama import Fore
@@ -33,7 +34,7 @@ class State():
 
     def get_colorize(self) -> bool:
         """Returns weather or not the terminal output is to be colorized"""
-        return self.color
+        return self.color and not os.environ.get('NO_COLOR')
 
     def get_color_by_severity(self, severity: str) -> AnsiCodes:
         """Get an ANSI color code given a severity
@@ -41,6 +42,8 @@ class State():
         Args:
             severity (str): either `neutral`, `info`, `warning` or `error`
         """
+        if os.environ.get('NO_COLOR'):
+            return ''
         return self.__colors_by_severity.get(severity, '')
 
     def get_hide(self, severity) -> bool:

--- a/tests/test_color.py
+++ b/tests/test_color.py
@@ -1,7 +1,22 @@
+import contextlib
+import os
+
 from .base import TestBaseClass
 
 # flake8: noqa S101 - n.a. for test files
+
+
 class TestColor(TestBaseClass):
+
+    @contextlib.contextmanager
+    def modified_env(**environ):
+        _bak = dict(os.environ)
+        os.environ.update(environ)
+        try:
+            yield
+        finally:
+            os.environ.clear()
+            os.environ.update(_bak)
 
     def test_get_color_by_severity(self):
         # local scoped import required due PATH manipulation
@@ -12,3 +27,18 @@ class TestColor(TestBaseClass):
         # local scoped import required due PATH manipulation
         from oelint_adv import state
         assert state.State().get_color_by_severity('unknown') == ''
+
+    def test_get_color_by_severity_no_color(self):
+        # local scoped import required due PATH manipulation
+        from oelint_adv import state
+        with TestColor.modified_env(NO_COLOR='1'):
+            assert isinstance(state.State().get_color_by_severity('info'), str)
+
+    def test_get_color_by_severity_missing(self):
+        # local scoped import required due PATH manipulation
+        from oelint_adv import state
+        with TestColor.modified_env(NO_COLOR='1'):
+            assert state.State().get_color_by_severity('info') == ''
+            assert state.State().get_color_by_severity('error') == ''
+            assert state.State().get_color_by_severity('warning') == ''
+            assert state.State().get_color_by_severity('unknown') == ''


### PR DESCRIPTION
even if the project configuration (or the CLI) requests colorization, sometime this leads to issues if
calling tools need to parse the output.
Add support for NO_COLOR (as described by https://no-color.org)

Closes #892

# Pull request checklist

## Bugfix

- [ ] A testcase was added to test the behavior

## New feature

- [x] A testcase was added to test the behavior
- [ ] ``wiki-creator.py`` was run and a new wiki document was filled with information
- [ ] New functions are documented with docstrings
- [x] No debug code is left
- [ ] README.md was updated to reflect the changes (check even if n.a.)
