### PR TITLE
pathhardcode: fix firmwaredir release

### DIFF
--- a/docs/wiki/oelint.vars.pathhardcode.md
+++ b/docs/wiki/oelint.vars.pathhardcode.md
@@ -38,7 +38,7 @@ The following variables are known
 - ``${systemd_unitdir}`` => ``/lib/systemd``
 - ``${systemd_user_unitdir}`` => ``/usr/lib/systemd/user``
 
-* 1 - starting from `wrynose` release
+* 1 - starting from `blacksail` release
 
 ```
 FILES:${PN} += "${docdir}"

--- a/oelint_adv/rule_base/rule_vars_pathhardcode.py
+++ b/oelint_adv/rule_base/rule_vars_pathhardcode.py
@@ -36,7 +36,7 @@ class VarsPathHardcode(Rule):
                          appendix=[v.strip('$').strip('{').strip('}') for v in self._map.values()])
 
     def check_release_range(self, release_range: List[str]) -> bool:
-        if 'wrynose' in release_range:
+        if 'blacksail' in release_range:
             self._map['/lib/firmware'] = '${firmwaredir}'
             self._map['${nonarch_base_libdir}/firmware'] = '${firmwaredir}'
             self._map.move_to_end('/lib')

--- a/tests/test_class_oelint_vars_pathhardcode.py
+++ b/tests/test_class_oelint_vars_pathhardcode.py
@@ -32,8 +32,6 @@ class TestClassOelintVarsPathHardcode(TestBaseClass):
         ('${servicedir}', '/srv'),
         ('${sharedstatedir}', '/com'),
         ('${sysconfdir}', '/etc'),
-        ('${firmwaredir}', '/lib/firmware'),
-        ('${firmwaredir}', '${nonarch_base_libdir}/firmware'),
     ])
     def test_bad(self, id_, occurrence, pair):
         id_ += '.{var}'.format(var=pair[0].strip('${}'))  # noqa: P103 - false positive
@@ -50,9 +48,10 @@ class TestClassOelintVarsPathHardcode(TestBaseClass):
     @pytest.mark.parametrize('id_', ['oelint.vars.pathhardcode'])
     @pytest.mark.parametrize('occurrence', [0])
     @pytest.mark.parametrize('pair', [
+        ('${firmwaredir}', '/lib/firmware'),
         ('${firmwaredir}', '${nonarch_base_libdir}/firmware'),
     ])
-    def test_bad_pre_wrynose(self, id_, occurrence, pair):
+    def test_bad_pre_blacksail(self, id_, occurrence, pair):
         id_ += '.{var}'.format(var=pair[0].strip('${}'))  # noqa: P103 - false positive
         for variation in [pair[1],
                           pair[1] + '/',
@@ -62,7 +61,25 @@ class TestClassOelintVarsPathHardcode(TestBaseClass):
             input_ = {
                 'oelint_adv_test.bb': self.__generate_sample_code(variation),
             }
-            self.check_for_id(self._create_args(input_, ['--release=scarthgap']), id_, occurrence)
+            self.check_for_id(self._create_args(input_, ['--release=wrynose']), id_, occurrence)
+
+    @pytest.mark.parametrize('id_', ['oelint.vars.pathhardcode'])
+    @pytest.mark.parametrize('occurrence', [1])
+    @pytest.mark.parametrize('pair', [
+        ('${firmwaredir}', '/lib/firmware'),
+        ('${firmwaredir}', '${nonarch_base_libdir}/firmware'),
+    ])
+    def test_bad_blacksail(self, id_, occurrence, pair):
+        id_ += '.{var}'.format(var=pair[0].strip('${}'))  # noqa: P103 - false positive
+        for variation in [pair[1],
+                          pair[1] + '/',
+                          os.path.join(pair[1], 'fooooo/ggsg'),
+                          os.path.join(pair[1], '*'),
+                          os.path.join('${D}', pair[1])]:
+            input_ = {
+                'oelint_adv_test.bb': self.__generate_sample_code(variation),
+            }
+            self.check_for_id(self._create_args(input_, ['--release=blacksail']), id_, occurrence)
 
     @pytest.mark.parametrize('id_', ['oelint.vars.pathhardcode'])
     @pytest.mark.parametrize('occurrence', [0])
@@ -87,6 +104,7 @@ class TestClassOelintVarsPathHardcode(TestBaseClass):
         ('${sharedstatedir}', '/com'),
         ('${sysconfdir}', '/etc'),
         ('${firmwaredir}', '/lib/firmware'),
+        ('${firmwaredir}', '${nonarch_base_libdir}/firmware'),
     ])
     def test_good(self, id_, occurrence, pair):
         id_ += '.{var}'.format(var=pair[0].strip('${}'))  # noqa: P103 - false positive


### PR DESCRIPTION
The `firmwaredir` variable was introduced after wrynose, not with that release. Fix the `pathhardcode` check so it only warns on blacksail or later.

Commit introducing `firmwaredir`: https://github.com/openembedded/openembedded-core/commit/2b75c7ba5e3aa6fc57d7b4afe59e2277b4d87de1
`bitbake.conf` on wrynose: https://github.com/openembedded/openembedded-core/blob/5d1aa5c806c061a2994f4decb59016610f093213/meta/conf/bitbake.conf#L42
`bitbake.conf` on master: https://github.com/openembedded/openembedded-core/blob/4a72f62d32e3fd3a88c2b92671f6dd75ef35fc44/meta/conf/bitbake.conf#L43

# Pull request checklist

## Bugfix

- [x] A testcase was added to test the behavior

## New feature

- ~[ ] A testcase was added to test the behavior~
- ~[ ] ``wiki-creator.py`` was run and a new wiki document was filled with information~
- ~[ ] New functions are documented with docstrings~
- ~[ ] No debug code is left~
- ~[ ] README.md was updated to reflect the changes (check even if n.a.)~
