### PR TITLE
data: add kernel-fit-image class

### DIFF
--- a/oelint_adv/data/oelint.json
+++ b/oelint_adv/data/oelint.json
@@ -21,6 +21,7 @@
             "image-container",
             "image-live",
             "kernel-fitimage",
+            "kernel-fit-image",
             "kernel-uimage",
             "license_image",
             "testimage"

--- a/tests/test_class_oelint_file_underscores.py
+++ b/tests/test_class_oelint_file_underscores.py
@@ -48,6 +48,10 @@ class TestClassOelintFileUnderscores(TestBaseClass):
                                  },
                                  {
                                      'oelint_adv_test.bb':
+                                     'inherit kernel-fit-image',
+                                 },
+                                 {
+                                     'oelint_adv_test.bb':
                                      'IMAGE_INSTALL += "foo"',
                                  },
                                  {


### PR DESCRIPTION
Replaced the older kernel-fitimage (without the dash) in 5.3 Whinlatter.

See: https://docs.yoctoproject.org/dev/migration-guides/migration-5.3.html#removed-classes

> * kernel-fitimage.bbclass: the class has been replaced by the [kernel-fit-image](https://docs.yoctoproject.org/dev/ref-manual/classes.html#ref-classes-kernel-fit-image) class. The new implementation resolves the long-standing [bug 12912](https://bugzilla.yoctoproject.org/show_bug.cgi?id=12912).

Should be handled like an image class in checks.

Also added to the underscores test as a "good" case.

The upstream recommendation in [meta/recipes-kernel/linux/linux-yocto-fitimage.bb](https://git.openembedded.org/openembedded-core/tree/meta/recipes-kernel/linux/linux-yocto-fitimage.bb) is to not add a version suffix and do

```bitbake
# Set the version of this recipe to the version of the included kernel
# (without taking the long way around via PV)
PKGV = "${@get_kernelversion_file("${STAGING_KERNEL_BUILDDIR}")}"
```

# Pull request checklist

## Bugfix

- [x] A testcase was added to test the behavior
