### PR TITLE
inlinesupp: fix line count

### DIFF
--- a/oelint_adv/rule_base/rule_bbclass_underscores.py
+++ b/oelint_adv/rule_base/rule_bbclass_underscores.py
@@ -18,5 +18,5 @@ class BBClassUnderscore(Rule):
         _files = {x.Origin for x in stash.GetItemsFor(filename=_file)}
         for file in _files:  # noqa: VNE002
             if '-' in os.path.basename(file):
-                res += self.finding(file, 1)
+                res += self.finding(file, 0)
         return res

--- a/oelint_adv/rule_base/rule_file_nospaces.py
+++ b/oelint_adv/rule_base/rule_file_nospaces.py
@@ -16,5 +16,5 @@ class FileNoSpaces(Rule):
         _layer_root = stash.GetLayerRoot(_file)
         _relpath = _file.replace(_layer_root, '').lstrip('/')
         if ' ' in _relpath:
-            res += self.finding(_file, 1)
+            res += self.finding(_file, 0)
         return res

--- a/oelint_adv/rule_base/rule_file_underscores.py
+++ b/oelint_adv/rule_base/rule_file_underscores.py
@@ -21,9 +21,9 @@ class FileNoSpaces(Rule):
                 return []
             _us = [x for x in _basename if x == '_']
             if len(_us) > 1:
-                res += self.finding(_file, 1,
+                res += self.finding(_file, 0,
                                     override_msg="Filename should not contain more than one '_'")
             elif not _us:
                 res += self.finding(
-                    _file, 1, override_msg="Filename should contain at least one '_' in the end")
+                    _file, 0, override_msg="Filename should contain at least one '_' in the end")
         return res

--- a/tests/test_inlinesuppressions.py
+++ b/tests/test_inlinesuppressions.py
@@ -240,3 +240,54 @@ class TestClassInlineSuppressions(TestBaseClass):
     def test_inlinesuppressions_bbappend_first_line(self, input_):
         self.check_for_id(self._create_args(input_),
                           'oelint.file.inlinesuppress_na', 0)
+
+    @pytest.mark.parametrize('input_',
+                             [
+                                 {
+                                     'oelint adv-test.bb':
+                                     '''
+                                     # nooelint: oelint.file.nospaces
+                                     A = "1"
+                                     ''',
+                                 },
+                             ],
+                             )
+    def test_inlinesuppressions_no_spaces_suppress(self, input_):
+        self.check_for_id(self._create_args(input_),
+                          'oelint.file.inlinesuppress_na', 0)
+        self.check_for_id(self._create_args(input_),
+                          'oelint.file.nospaces', 0)
+
+    @pytest.mark.parametrize('input_',
+                             [
+                                 {
+                                     'oelint-adv-test.bbclass':
+                                     '''
+                                     # nooelint: oelint.bbclass.underscores
+                                     A = "1"
+                                     ''',
+                                 },
+                             ],
+                             )
+    def test_inlinesuppressions_bbclass_unserscore_suppress(self, input_):
+        self.check_for_id(self._create_args(input_),
+                          'oelint.file.inlinesuppress_na', 0)
+        self.check_for_id(self._create_args(input_),
+                          'oelint.bbclass.underscores', 0)
+
+    @pytest.mark.parametrize('input_',
+                             [
+                                 {
+                                     'oelint-adv-test.bb':
+                                     '''
+                                     # nooelint: oelint.file.underscores
+                                     A = "1"
+                                     ''',
+                                 },
+                             ],
+                             )
+    def test_inlinesuppressions_file_unserscore_suppress(self, input_):
+        self.check_for_id(self._create_args(input_),
+                          'oelint.file.inlinesuppress_na', 0)
+        self.check_for_id(self._create_args(input_),
+                          'oelint.file.underscores', 0)


### PR DESCRIPTION
for file based rules to line 0 to
fully enable proper inline suppression.

Closes #904

# Pull request checklist

## Bugfix

- [x] A testcase was added to test the behavior

## New feature

- [ ] A testcase was added to test the behavior
- [ ] ``wiki-creator.py`` was run and a new wiki document was filled with information
- [ ] New functions are documented with docstrings
- [ ] No debug code is left
- [ ] README.md was updated to reflect the changes (check even if n.a.)
