### PR TITLE
pythonrdepends: check for python meta-package

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ Rules marked with **[I]** need to be activated through [a rule file](#defining-a
 * [oelint.vars.pnbpnusage](https://github.com/priv-kweihmann/oelint-adv/blob/master/docs/wiki/oelint.vars.pnbpnusage.md) - \$\{BPN\} should be used instead of \$\{PN\} **[F]**
 * [oelint.vars.pnusagediscouraged](https://github.com/priv-kweihmann/oelint-adv/blob/master/docs/wiki/oelint.vars.pnusagediscouraged.md) - Variable shouldn't contain \$\{PN\} or \$\{BPN\}
 * [oelint.vars.pythonpnusage](https://github.com/priv-kweihmann/oelint-adv/blob/master/docs/wiki/oelint.vars.pythonpnusage.md) - python3 should be used instead of \$\{PYTHON_PN\} **[F]** (scarthgap+)
+* [oelint.vars.pythonrdepends](https://github.com/priv-kweihmann/oelint-adv/blob/master/docs/wiki/oelint.vars.pythonrdepends.md) - Check if meta package for python is used instead of the sub-packages
 * [oelint.vars.renamed](https://github.com/priv-kweihmann/oelint-adv/blob/master/docs/wiki/oelint.vars.renamed.md) - Warn about renamed or deprecated variables **[F]**
 * [oelint.vars.sectionlowercase](https://github.com/priv-kweihmann/oelint-adv/blob/master/docs/wiki/oelint.vars.sectionlowercase.md) - SECTION should be lowercase only **[F]**
 * [oelint.vars.spacesassignment](https://github.com/priv-kweihmann/oelint-adv/blob/master/docs/wiki/oelint.vars.spacesassignment.md) - ' = ' should be correct variable assignment

--- a/docs/wiki/oelint.vars.pythonrdepends.md
+++ b/docs/wiki/oelint.vars.pythonrdepends.md
@@ -1,0 +1,25 @@
+# oelint.vars.pythonrdepends
+
+severity: warning
+
+## Example
+
+```
+RDEPENDS:${PN} = "python3"
+```
+
+## Why is this bad?
+
+This will install the entire python ecosystem on your target, which adds >50Mb of footprint.
+It is much better to just install the sub-package needed, like ``python3-core``.
+
+## Ways to fix it
+
+Find the needed packages using the information found at
+
+- `meta/recipes-devtools/python/python3/python3-manifest.json`
+- `meta/recipes-devtools/python/python/python-manifest.json`
+
+in the `openembedded-core`/`poky` repository.
+
+or recreate the recipe using `recipetool`

--- a/oelint_adv/rule_base/rule_var_python_rdepends.py
+++ b/oelint_adv/rule_base/rule_var_python_rdepends.py
@@ -1,0 +1,29 @@
+from typing import List, Tuple
+
+from oelint_parser.cls_item import Variable
+from oelint_parser.cls_stash import Stash
+
+from oelint_adv.cls_rule import Rule, Classification
+
+
+class VarPythonRdepends(Rule):
+    def __init__(self) -> None:
+        super().__init__(id='oelint.vars.pythonrdepends',
+                         severity='warning',
+                         run_on=[Classification.BBAPPEND,
+                                 Classification.RECIPE],
+                         message='{var} installs the entire python ecosystem. Most likely you only want sub packages like {var}-core',
+                         valid_from_release='scarthgap')
+
+    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+        res = []
+        items: List[Variable] = stash.GetItemsFor(filename=_file,
+                                                  classifier=Variable.CLASSIFIER,
+                                                  attribute=Variable.ATTR_VAR,
+                                                  attributeValue='RDEPENDS')
+        for item in items:
+            for needle in ['python', 'python3', '${PYTHON_PN}']:
+                if needle in item.get_items():
+                    res += self.finding(item.Origin, item.InFileLine,
+                                        self.Msg.format(var=needle))
+        return res

--- a/tests/test_class_oelint_vars_pythonrdepends.py
+++ b/tests/test_class_oelint_vars_pythonrdepends.py
@@ -1,0 +1,52 @@
+import pytest  # noqa: I900
+
+from .base import TestBaseClass
+
+
+class TestClassOelintVarsPythonRdepends(TestBaseClass):
+
+    @pytest.mark.parametrize('id_', ['oelint.vars.pythonrdepends'])
+    @pytest.mark.parametrize('occurrence', [1])
+    @pytest.mark.parametrize('input_',
+                             [
+                                 {
+                                     'oelint_adv_test.bb':
+                                     'RDEPENDS:${PN} = "${PYTHON_PN}"',
+                                 },
+                                 {
+                                     'oelint_adv_test.bb':
+                                     'RDEPENDS:${PN} = "python"',
+                                 },
+                                 {
+                                     'oelint_adv_test.bb':
+                                     'RDEPENDS:${PN} = "python3"',
+                                 },
+                             ],
+                             )
+    def test_bad(self, input_, id_, occurrence):
+        self.check_for_id(self._create_args(input_), id_, occurrence)
+
+    @pytest.mark.parametrize('id_', ['oelint.vars.pythonrdepends'])
+    @pytest.mark.parametrize('occurrence', [0])
+    @pytest.mark.parametrize('input_',
+                             [
+                                 {
+                                     'oelint_adv_test.bb':
+                                     'RDEPENDS:${PN} = "${PYTHON_PN}-core"',
+                                 },
+                                 {
+                                     'oelint_adv_test.bb':
+                                     'RDEPENDS:${PN} = "python-core"',
+                                 },
+                                 {
+                                     'oelint_adv_test.bb':
+                                     'RDEPENDS:${PN} = "python3-core"',
+                                 },
+                                 {
+                                     'oelint_adv_test.bb':
+                                     'RDEPENDS:${PN} = "python3-somethingelse"',
+                                 },
+                             ],
+                             )
+    def test_good(self, input_, id_, occurrence):
+        self.check_for_id(self._create_args(input_), id_, occurrence)


### PR DESCRIPTION
being used, instead of the sub-packages.
This should effectively warn about bloat in the
assembled images.

Closes #907

# Pull request checklist

## Bugfix

- [ ] A testcase was added to test the behavior

## New feature

- [x] A testcase was added to test the behavior
- [x] ``wiki-creator.py`` was run and a new wiki document was filled with information
- [x] New functions are documented with docstrings
- [x] No debug code is left
- [x] README.md was updated to reflect the changes (check even if n.a.)
