### PR TITLE
task.nopythonprefix: do not remove trailing brackets

### DIFF
--- a/oelint_adv/rule_base/rule_tasks_nopython_prefix.py
+++ b/oelint_adv/rule_base/rule_tasks_nopython_prefix.py
@@ -19,7 +19,7 @@ class TaskNoPythonPrefix(Rule):
         items: List[Function] = stash.GetItemsFor(filename=_file, classifier=Function.CLASSIFIER)
         for item in items:
             try:
-                ast.parse(textwrap.dedent(item.FuncBodyRaw.rstrip('}\n')), 'tempfile')
+                ast.parse(textwrap.dedent(item.FuncBodyRaw), 'tempfile')
             except Exception:
                 if item.IsPython:
                     res += self.finding(item.Origin, item.InFileLine)

--- a/tests/test_class_oelint_task_nopythonprefix.py
+++ b/tests/test_class_oelint_task_nopythonprefix.py
@@ -45,6 +45,17 @@ class TestClassOelintTaskNoPythonPrefix(TestBaseClass):
                                      }
                                      ''',
                                  },
+                                 {
+                                     'oelint_adv_test.bb':
+                                     '''
+                                     python do_baz() {
+                                         import json
+                                         foo = {
+                                             "bar": []
+                                         }
+                                     }
+                                     ''',
+                                 },
                              ],
                              )
     def test_good(self, input_, id_, occurrence):


### PR DESCRIPTION
as this could be code.
The workaround prior seemed to be a result of a
shortcoming of the parser, which seems to be fixed now.

Closes #915

# Pull request checklist

## Bugfix

- [x] A testcase was added to test the behavior

## New feature

- [ ] A testcase was added to test the behavior
- [ ] ``wiki-creator.py`` was run and a new wiki document was filled with information
- [ ] New functions are documented with docstrings
- [ ] No debug code is left
- [ ] README.md was updated to reflect the changes (check even if n.a.)
