### PR TITLE
inappclassoverride: ignore class settings

### DIFF
--- a/oelint_adv/rule_base/rule_vars_inapp_class_override.py
+++ b/oelint_adv/rule_base/rule_vars_inapp_class_override.py
@@ -21,6 +21,9 @@ class VarsInappClassOverride(Rule):
         bbclassextend = stash.ExpandVar(_file, Variable.ATTR_VAR, attributeValue='BBCLASSEXTEND').get('BBCLASSEXTEND', [])
 
         for item in stash.GetItemsFor(filename=_file, classifier=[Variable.CLASSIFIER, Function.CLASSIFIER]):
+            if item.Origin.endswith('.bbclass'):
+                # ignore all class related settings
+                continue
             for needle in [('class-native', 'native'), ('class-nativesdk', 'nativesdk')]:
                 override, class_ = needle
                 if override not in item.SubItems:

--- a/tests/test_class_oelint_vars_inappclassoverride.py
+++ b/tests/test_class_oelint_vars_inappclassoverride.py
@@ -154,6 +154,17 @@ class TestClassOelintVarsInAppClassOverride(TestBaseClass):
                                      inherit nativesdk
                                      ''',
                                  },
+                                 {
+                                     'classes/test.bbclass':
+                                     '''
+                                    A:nativesdk = "1"
+                                    ''',
+                                     'conf/layer.conf': '',
+                                     'oelint_adv_test.bb':
+                                     '''
+                                    inherit test
+                                    ''',
+                                 },
                              ],
                              )
     def test_good(self, input_, id_, occurrence):


### PR DESCRIPTION
as bbclasses are meant to be reusable, it is fine
to ignore all findings from them, even if
the inheriting recipe doesn't properly set
BBCLASSEXTEND or inherits the correct class

Closes #917
Closes #918

# Pull request checklist

## Bugfix

- [x] A testcase was added to test the behavior

## New feature

- [ ] A testcase was added to test the behavior
- [ ] ``wiki-creator.py`` was run and a new wiki document was filled with information
- [ ] New functions are documented with docstrings
- [ ] No debug code is left
- [ ] README.md was updated to reflect the changes (check even if n.a.)
