### PR TITLE
multiinherit: check only within a file

### DIFF
--- a/oelint_adv/rule_base/rule_vars_multiinherit.py
+++ b/oelint_adv/rule_base/rule_vars_multiinherit.py
@@ -18,8 +18,9 @@ class VarMultiInherit(Rule):
         keys = []
         for i in items:
             for y in i.get_items():
-                if y not in keys:
-                    keys.append(y)
+                _map_needle = f'{i.Origin}:{y}'
+                if _map_needle not in keys:
+                    keys.append(_map_needle)
                 else:
                     res += self.finding(i.Origin, i.InFileLine,
                                         self.Msg.replace('{inherit}', y))

--- a/tests/test_class_oelint_var_multiinherit.py
+++ b/tests/test_class_oelint_var_multiinherit.py
@@ -38,6 +38,14 @@ class TestClassOelintVarMultiInherit(TestBaseClass):
                                              pkgconfig
                                      ''',
                                  },
+                                 {
+                                     'classes/d.class': '',
+                                     'classes/c.class': 'inherit d',
+                                     'classes/b.class': 'inherit d',
+                                     'classes/a.class': 'inherit d',
+                                     'conf/layer.conf': '',
+                                     'oelint_adv_test.bb': 'inherit a b c',
+                                 },
                              ],
                              )
     def test_good(self, input_, id_, occurrence):


### PR DESCRIPTION
and not for e.g. nested common bbclasses inherited through other classes.
Make this check only probe for inherits within the same file origin.

Closes #914

# Pull request checklist

## Bugfix

- [x] A testcase was added to test the behavior

## New feature

- [ ] A testcase was added to test the behavior
- [ ] ``wiki-creator.py`` was run and a new wiki document was filled with information
- [ ] New functions are documented with docstrings
- [ ] No debug code is left
- [ ] README.md was updated to reflect the changes (check even if n.a.)
