### PR TITLE
ci/autorelease: fix path mask

### DIFF
--- a/.github/workflows/autorelease.yml
+++ b/.github/workflows/autorelease.yml
@@ -22,7 +22,7 @@ concurrency:
 env:
   VERSION_FILE: oelint_adv/version.py
   PROJ_CONF: pyproject.toml
-  MODULE_CODE: oelint_adv/*
+  MODULE_CODE: oelint_adv/**
   PYPI_PUBLISH: 1
 
 jobs:


### PR DESCRIPTION
for module code, as most of the changes will
happen in subfolders of the code not just only
in the root.
Use ** to catch all of them
