### PR TITLE
oelint_adv: Small corrections in some messages

### DIFF
--- a/oelint_adv/rule_base/rule_var_descriptiontooshort.py
+++ b/oelint_adv/rule_base/rule_var_descriptiontooshort.py
@@ -10,7 +10,7 @@ class VarDescSameTooBrief(Rule):
     def __init__(self):
         super().__init__(id='oelint.vars.descriptiontoobrief',
                          severity='warning',
-                         message="'DESCRIPTION' is the shorter than 'SUMMARY'")
+                         message="'DESCRIPTION' is shorter than 'SUMMARY'")
 
     def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
         res = []

--- a/oelint_adv/rule_base/rule_var_section_lowercase.py
+++ b/oelint_adv/rule_base/rule_var_section_lowercase.py
@@ -10,7 +10,7 @@ class VarSectionLowercase(Rule):
     def __init__(self) -> None:
         super().__init__(id='oelint.vars.sectionlowercase',
                          severity='warning',
-                         message="'SECTION' should only lowercase characters")
+                         message="'SECTION' should only contain lowercase characters")
 
     def __getMatches(self, _file: str, stash: Stash) -> List[Variable]:
         res = []


### PR DESCRIPTION
Some minimal corrections in the messages returned
by a couple of oelint rules.

# Pull request checklist

## Bugfix

- [ ] A testcase was added to test the behavior

## New feature

- [ ] A testcase was added to test the behavior
- [ ] ``wiki-creator.py`` was run and a new wiki document was filled with information
- [ ] New functions are documented with docstrings
- [ ] No debug code is left
- [ ] README.md was updated to reflect the changes (check even if n.a.)