### PR TITLE
outputformat: implement GitLab Code Quality report

### DIFF
--- a/README.md
+++ b/README.md
@@ -565,9 +565,9 @@ args = create_lib_arguments(['file to check', 'another file to check']])
 
 results = run(args)
 
-# the results will be a List[Tuple[Tuple[str, int, str], str]]
+# the results will be a List[Tuple[Tuple[str, int, str, str], str]]
 # each item is
-#  [0] - 'path to the finding', 'line of the finding', 'id of the finding'
+#  [0] - 'path to the finding', 'line of the finding', 'id of the finding', 'severity of the finding'
 #  [1] - 'message'
 ```
 

--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ class FooMagicRule(Rule):
                          severity="error",
                          message="Too much foo happening here")
 
-    def check(self, _file, stash):
+    def check(self, _file, stash) -> list[Rule.Finding]
         res = []
         items = stash.GetItemsFor(filename=_file)
         for i in items:

--- a/README.md
+++ b/README.md
@@ -131,6 +131,22 @@ When running with ``--outputformat=junit`` you will get a JUnit XML report.
 If the run found issues, you will get each finding as a separate failing testcase.
 In the case nothing was found you will get a `synthetic` passing testcase
 
+### GitLab Code Quality
+
+Run with ``--outputformat=gitlab-codequality`` to get the output formatted as a [GitLab Code Quality report](https://docs.gitlab.com/ci/testing/code_quality/#code-quality-report-format).
+
+When running the linter in a GitLab CI job, the resulting output can be uploaded as an artifact of type [`reports:codequality`](https://docs.gitlab.com/ci/yaml/artifacts_reports/#artifactsreportscodequality).
+This will result in the findings being displayed in the Code Quality pages of pipelines and merge requests.
+
+The finding severities of this tool are mapped to the GitLab severities as follows:
+ - `info -> info`
+ - `warning -> minor`
+ - `error -> critical`
+
+The view will provide a link to the corresponding code location. Depending on the directory structure, using the `--relpaths` option is likely necessary for this to work
+because GitLab expects file paths to be relative to the repository root.
+
+
 ## Apply automatic fixing
 
 Some of the rules are capable of fixing the issues found automatically.

--- a/oelint_adv/cls_rule.py
+++ b/oelint_adv/cls_rule.py
@@ -5,7 +5,7 @@ import os
 import pkgutil
 import sys
 from enum import Enum
-from typing import FrozenSet, Iterable, List, Tuple
+from typing import FrozenSet, Iterable, List
 
 from colorama import Style
 from oelint_parser.cls_stash import Stash
@@ -38,6 +38,9 @@ class Classification(Enum):
 
 
 class Rule:
+    Finding = tuple[tuple[str, int, str], frozenset[str], str]
+    """ Path, line, ID, matrix, Human readable finding (possibly with color codes)"""
+
     def __init__(self,
                  id: str = '',  # noqa: A002, VNE003
                  severity: str = '',
@@ -152,7 +155,7 @@ class Rule:
         """
         return any(set(groupclass).intersection(self._run_on))
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> List[Finding]:
         """Stub for running check - is overridden by each rule
 
         Arguments:
@@ -182,7 +185,7 @@ class Rule:
                 override_msg: str = None,
                 appendix: str = None,
                 blockoffset: int = 0,
-                severity_override: str = '') -> Tuple[Tuple[str, int], List[str], str]:
+                severity_override: str = '') -> list[Finding]:
         """Called by rule to indicate a finding
 
         Arguments:
@@ -196,7 +199,7 @@ class Rule:
             severity_override {str} -- override the base severity (empty == use base)
 
         Returns:
-            Tuple[Tuple[str, int, str], List[str], str] -- Path, line, ID, matrix, Human readable finding (possibly with color codes)
+            Rule.Finding -- Path, line, ID, severity, matrix, Human readable finding (possibly with color codes). Empty if suppressed or hidden.
         """
         if override_msg is None:
             override_msg = self.Msg

--- a/oelint_adv/cls_rule.py
+++ b/oelint_adv/cls_rule.py
@@ -39,7 +39,7 @@ class Classification(Enum):
 
 class Rule:
     Finding = tuple[tuple[str, int, str], frozenset[str], str]
-    """ Path, line, ID, matrix, Human readable finding (possibly with color codes)"""
+    '''Path, line, ID, severity, matrix, Human readable finding (possibly with color codes)'''
 
     def __init__(self,
                  id: str = '',  # noqa: A002, VNE003
@@ -243,7 +243,7 @@ class Rule:
                                                       id=_display_id, msg=override_msg,
                                                       wikiurl=wikiurl,
                                                       rungroup=','.join(self.__rungroup))
-        return [((_path, _line, _display_id), self.__matrix, f'{_color}{_msg}{_style}')]
+        return [((_path, _line, _display_id, _severity), self.__matrix, f'{_color}{_msg}{_style}')]
 
     def __repr__(self) -> str:
         return '{id}'.format(id=self.ID)  # pragma: no cover

--- a/oelint_adv/core.py
+++ b/oelint_adv/core.py
@@ -215,7 +215,7 @@ def group_run(group: List[Tuple],
               fix: bool,
               rules: List[Rule],
               state: State,
-              persistent: bool = True) -> Tuple[List[Tuple[str, int, str]], Dict[str, str]]:
+              persistent: bool = True) -> Tuple[List[Rule.Finding], Dict[str, str]]:
     fixedfiles = []
     group_files, matrix, stash_params = group
     stash = Stash(
@@ -533,7 +533,7 @@ def arguments_post(args: argparse.Namespace) -> argparse.Namespace:  # noqa: C90
     return args
 
 
-def run(args: argparse.Namespace, persistent: bool = True) -> Tuple[List[Tuple[str, int, str]], Dict[str, str]]:
+def run(args: argparse.Namespace, persistent: bool = True) -> Tuple[List[Tuple[Tuple[str, int, str], str]], Dict[str, str]]:
     rules = load_rules(args, add_rules=args.addrules,
                        add_dirs=args.customrules)
     _loaded_ids = []

--- a/oelint_adv/core.py
+++ b/oelint_adv/core.py
@@ -533,7 +533,7 @@ def arguments_post(args: argparse.Namespace) -> argparse.Namespace:  # noqa: C90
     return args
 
 
-def run(args: argparse.Namespace, persistent: bool = True) -> Tuple[List[Tuple[Tuple[str, int, str], str]], Dict[str, str]]:
+def run(args: argparse.Namespace, persistent: bool = True) -> Tuple[List[Tuple[Tuple[str, int, str, str], str]], Dict[str, str]]:
     rules = load_rules(args, add_rules=args.addrules,
                        add_dirs=args.customrules)
     _loaded_ids = []

--- a/oelint_adv/outputformat.py
+++ b/oelint_adv/outputformat.py
@@ -1,4 +1,6 @@
 import argparse
+import hashlib
+import json
 import sys
 from typing import List, Tuple
 
@@ -45,7 +47,40 @@ class OutputFormatJUnit():
             args.output.close()  # pragma: no cover
 
 
+class OutputFormatGitlabCodequality():
+    _SEVERITY_TO_GITLAB = {
+        'info': 'info',
+        'warning': 'minor',
+        'error': 'critical',
+    }
+
+    def __init__(self, args: argparse.Namespace, issues: List[Tuple[Tuple[str, int, str, str], str]]) -> None:
+        json_a = [self._to_cq_issue(issue) for issue in issues]
+
+        if args.output != sys.stderr:
+            args.output = open(args.output, 'w')  # pragma: no cover
+
+        json.dump(json_a, args.output, indent=2)
+
+        if args.output != sys.stderr:
+            args.output.close()  # pragma: no cover
+
+    def _to_cq_issue(self, issue: Tuple[Tuple[str, int, str, str], str]) -> str:
+        path, line, check_name, severity = issue[0]
+        msg = issue[1]
+        out = {
+            'description': msg,
+            'check_name': check_name,
+            'fingerprint': hashlib.sha256(msg.encode('utf-8')).hexdigest(),
+            'location': {'path': path, 'lines': {'begin': line}},
+            'severity': self._SEVERITY_TO_GITLAB.get(severity, 'minor'),
+        }
+
+        return out
+
+
 _OUTPUT_FORMATS = {
     'stdout': OutputFormatStdOut,
     'junit': OutputFormatJUnit,
+    'gitlab-codequality': OutputFormatGitlabCodequality,
 }

--- a/oelint_adv/outputformat.py
+++ b/oelint_adv/outputformat.py
@@ -5,7 +5,7 @@ from typing import List, Tuple
 
 class OutputFormatStdOut():
 
-    def __init__(self, args: argparse.Namespace, issues: List[Tuple[Tuple[str, int, str], str]]) -> None:
+    def __init__(self, args: argparse.Namespace, issues: List[Tuple[Tuple[str, int, str, str], str]]) -> None:
         if args.output != sys.stderr:
             args.output = open(args.output, 'w')  # pragma: no cover
         args.output.write('\n'.join([x[1] for x in issues]))
@@ -17,7 +17,7 @@ class OutputFormatStdOut():
 
 class OutputFormatJUnit():
 
-    def __init__(self, args: argparse.Namespace, issues: List[Tuple[Tuple[str, int, str], str]]) -> None:
+    def __init__(self, args: argparse.Namespace, issues: List[Tuple[Tuple[str, int, str, str], str]]) -> None:
         output = '<?xml version="1.0" encoding="UTF-8"?>\n'
         output += '<testsuites>\n'
         if not issues:
@@ -26,7 +26,7 @@ class OutputFormatJUnit():
         else:
             output += f'<testsuite id="oelint-adv" name="oelint-adv" tests="{len(issues)}" failures="{len(issues)}" errors="0" skipped="0">\n'
             for x in issues:
-                _file, _line, _id = x[0]
+                _file, _line, _id, _ = x[0]
                 _msg = x[1]
                 output += f'<testcase name="{_id}" file="{_file}" line="{_line}">\n'
                 output += f'<failure message="{_id}" type="failure">\n'

--- a/oelint_adv/outputformat.py
+++ b/oelint_adv/outputformat.py
@@ -5,7 +5,7 @@ from typing import List, Tuple
 
 class OutputFormatStdOut():
 
-    def __init__(self, args: argparse.Namespace, issues: List[Tuple[str, int, str]]) -> None:
+    def __init__(self, args: argparse.Namespace, issues: List[Tuple[Tuple[str, int, str], str]]) -> None:
         if args.output != sys.stderr:
             args.output = open(args.output, 'w')  # pragma: no cover
         args.output.write('\n'.join([x[1] for x in issues]))
@@ -17,7 +17,7 @@ class OutputFormatStdOut():
 
 class OutputFormatJUnit():
 
-    def __init__(self, args: argparse.Namespace, issues: List[Tuple[str, int, str]]) -> None:
+    def __init__(self, args: argparse.Namespace, issues: List[Tuple[Tuple[str, int, str], str]]) -> None:
         output = '<?xml version="1.0" encoding="UTF-8"?>\n'
         output += '<testsuites>\n'
         if not issues:

--- a/oelint_adv/rule_base/rule_append_protvars.py
+++ b/oelint_adv/rule_base/rule_append_protvars.py
@@ -15,7 +15,7 @@ class VarQuoted(Rule):
                          run_on=[Classification.BBAPPEND],
                          appendix=CONSTANTS.GetByPath('variables/protected-append'))
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         items = stash.GetItemsFor(
             filename=_file, classifier=Variable.CLASSIFIER)

--- a/oelint_adv/rule_base/rule_append_protvars.py
+++ b/oelint_adv/rule_base/rule_append_protvars.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Variable
 from oelint_parser.cls_stash import Stash
@@ -15,7 +15,7 @@ class VarQuoted(Rule):
                          run_on=[Classification.BBAPPEND],
                          appendix=CONSTANTS.GetByPath('variables/protected-append'))
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         items = stash.GetItemsFor(
             filename=_file, classifier=Variable.CLASSIFIER)

--- a/oelint_adv/rule_base/rule_bbclass_exportfunctions.py
+++ b/oelint_adv/rule_base/rule_bbclass_exportfunctions.py
@@ -13,7 +13,7 @@ class ExportFunctionsDash(Rule):
                          run_on=[Classification.BBCLASS],
                          message="EXPORT_FUNCTIONS should not contain '-', replace by '_'.")
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         for item in stash.GetItemsFor(filename=_file,
                                       classifier=FunctionExports.CLASSIFIER):

--- a/oelint_adv/rule_base/rule_bbclass_exportfunctions.py
+++ b/oelint_adv/rule_base/rule_bbclass_exportfunctions.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import FunctionExports
 from oelint_parser.cls_stash import Stash
@@ -13,7 +13,7 @@ class ExportFunctionsDash(Rule):
                          run_on=[Classification.BBCLASS],
                          message="EXPORT_FUNCTIONS should not contain '-', replace by '_'.")
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         for item in stash.GetItemsFor(filename=_file,
                                       classifier=FunctionExports.CLASSIFIER):

--- a/oelint_adv/rule_base/rule_bbclass_underscores.py
+++ b/oelint_adv/rule_base/rule_bbclass_underscores.py
@@ -13,7 +13,7 @@ class BBClassUnderscore(Rule):
                          run_on=[Classification.BBCLASS],
                          message="bbclass filenames should not contain '-'. Replace it by '_'")
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         _files = {x.Origin for x in stash.GetItemsFor(filename=_file)}
         for file in _files:  # noqa: VNE002

--- a/oelint_adv/rule_base/rule_bbclass_underscores.py
+++ b/oelint_adv/rule_base/rule_bbclass_underscores.py
@@ -1,5 +1,5 @@
 import os
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_stash import Stash
 
@@ -13,7 +13,7 @@ class BBClassUnderscore(Rule):
                          run_on=[Classification.BBCLASS],
                          message="bbclass filenames should not contain '-'. Replace it by '_'")
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         _files = {x.Origin for x in stash.GetItemsFor(filename=_file)}
         for file in _files:  # noqa: VNE002

--- a/oelint_adv/rule_base/rule_file_include.py
+++ b/oelint_adv/rule_base/rule_file_include.py
@@ -13,7 +13,7 @@ class FileIncludeNotFound(Rule):
                          severity='warning',
                          message="'{FILE}' was not found")
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         for item in stash.GetItemsFor(filename=_file,
                                       classifier=Include.CLASSIFIER):

--- a/oelint_adv/rule_base/rule_file_include.py
+++ b/oelint_adv/rule_base/rule_file_include.py
@@ -1,5 +1,5 @@
 import os
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Include
 from oelint_parser.cls_stash import Stash
@@ -13,7 +13,7 @@ class FileIncludeNotFound(Rule):
                          severity='warning',
                          message="'{FILE}' was not found")
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         for item in stash.GetItemsFor(filename=_file,
                                       classifier=Include.CLASSIFIER):

--- a/oelint_adv/rule_base/rule_file_includevsrequire.py
+++ b/oelint_adv/rule_base/rule_file_includevsrequire.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Include
 from oelint_parser.cls_stash import Stash
@@ -12,7 +12,7 @@ class FileIncludeVsRequire(Rule):
                          severity='warning',
                          message="Use 'require {FILE}' instead of 'include {FILE}'")
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         for item in stash.GetItemsFor(filename=_file,
                                       classifier=Include.CLASSIFIER):

--- a/oelint_adv/rule_base/rule_file_includevsrequire.py
+++ b/oelint_adv/rule_base/rule_file_includevsrequire.py
@@ -12,7 +12,7 @@ class FileIncludeVsRequire(Rule):
                          severity='warning',
                          message="Use 'require {FILE}' instead of 'include {FILE}'")
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         for item in stash.GetItemsFor(filename=_file,
                                       classifier=Include.CLASSIFIER):

--- a/oelint_adv/rule_base/rule_file_inlinesuppress_na.py
+++ b/oelint_adv/rule_base/rule_file_inlinesuppress_na.py
@@ -13,7 +13,7 @@ class FileNotApplicableInlineSuppression(Rule):
                          message="Inline suppression for '{id}' is not needed")
         self._state = state
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         # special handling from main
         # do not announce any finding
         return []

--- a/oelint_adv/rule_base/rule_file_inlinesuppress_na.py
+++ b/oelint_adv/rule_base/rule_file_inlinesuppress_na.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_stash import Stash
 
@@ -13,7 +13,7 @@ class FileNotApplicableInlineSuppression(Rule):
                          message="Inline suppression for '{id}' is not needed")
         self._state = state
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         # special handling from main
         # do not announce any finding
         return []

--- a/oelint_adv/rule_base/rule_file_nospaces.py
+++ b/oelint_adv/rule_base/rule_file_nospaces.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_stash import Stash
 
@@ -11,7 +11,7 @@ class FileNoSpaces(Rule):
                          severity='error',
                          message='Path to file contains spaces. Please remove them')
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         _layer_root = stash.GetLayerRoot(_file)
         _relpath = _file.replace(_layer_root, '').lstrip('/')

--- a/oelint_adv/rule_base/rule_file_nospaces.py
+++ b/oelint_adv/rule_base/rule_file_nospaces.py
@@ -11,7 +11,7 @@ class FileNoSpaces(Rule):
                          severity='error',
                          message='Path to file contains spaces. Please remove them')
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         _layer_root = stash.GetLayerRoot(_file)
         _relpath = _file.replace(_layer_root, '').lstrip('/')

--- a/oelint_adv/rule_base/rule_file_patch_inactiveupstreamdetails.py
+++ b/oelint_adv/rule_base/rule_file_patch_inactiveupstreamdetails.py
@@ -20,7 +20,7 @@ class FilePatchIsUpstreamStatusInactiveUpstreamDetails(Rule):
         # Find matching SRC_URI assignment
         return [x for x in items if x.VarValue.find(os.path.basename(path)) != -1]
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         patches = stash.GetFiles(_file, '*.patch')
         patches.extend(stash.GetFiles(_file, '*.diff'))

--- a/oelint_adv/rule_base/rule_file_patch_inactiveupstreamdetails.py
+++ b/oelint_adv/rule_base/rule_file_patch_inactiveupstreamdetails.py
@@ -1,5 +1,5 @@
 import os
-from typing import List, Tuple
+from typing import List
 
 import regex  # noqa: I900
 from oelint_parser.cls_item import Variable
@@ -20,7 +20,7 @@ class FilePatchIsUpstreamStatusInactiveUpstreamDetails(Rule):
         # Find matching SRC_URI assignment
         return [x for x in items if x.VarValue.find(os.path.basename(path)) != -1]
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         patches = stash.GetFiles(_file, '*.patch')
         patches.extend(stash.GetFiles(_file, '*.diff'))

--- a/oelint_adv/rule_base/rule_file_patch_inappropriatemsg.py
+++ b/oelint_adv/rule_base/rule_file_patch_inappropriatemsg.py
@@ -1,5 +1,5 @@
 import os
-from typing import List, Tuple
+from typing import List
 
 import regex  # noqa: I900
 from oelint_parser.cls_item import Variable
@@ -22,7 +22,7 @@ class FilePatchIsUpstreamStatusInAppMsg(Rule):
         # Find matching SRC_URI assignment
         return [x for x in items if x.VarValue.find(os.path.basename(path)) != -1]
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         patches = stash.GetFiles(_file, '*.patch')
         patches.extend(stash.GetFiles(_file, '*.diff'))

--- a/oelint_adv/rule_base/rule_file_patch_inappropriatemsg.py
+++ b/oelint_adv/rule_base/rule_file_patch_inappropriatemsg.py
@@ -22,7 +22,7 @@ class FilePatchIsUpstreamStatusInAppMsg(Rule):
         # Find matching SRC_URI assignment
         return [x for x in items if x.VarValue.find(os.path.basename(path)) != -1]
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         patches = stash.GetFiles(_file, '*.patch')
         patches.extend(stash.GetFiles(_file, '*.diff'))

--- a/oelint_adv/rule_base/rule_file_patch_signedoff.py
+++ b/oelint_adv/rule_base/rule_file_patch_signedoff.py
@@ -1,5 +1,5 @@
 import os
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Variable
 from oelint_parser.cls_stash import Stash
@@ -14,7 +14,7 @@ class FilePatchIsSignedOff(Rule):
                          run_on=[Classification.BBAPPEND, Classification.RECIPE],
                          message="Patch '{FILE}' should contain a Signed-off-by entry")
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         items = stash.GetFiles(_file, '*.patch')
         items.extend(stash.GetFiles(_file, '*.diff'))

--- a/oelint_adv/rule_base/rule_file_patch_signedoff.py
+++ b/oelint_adv/rule_base/rule_file_patch_signedoff.py
@@ -14,7 +14,7 @@ class FilePatchIsSignedOff(Rule):
                          run_on=[Classification.BBAPPEND, Classification.RECIPE],
                          message="Patch '{FILE}' should contain a Signed-off-by entry")
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         items = stash.GetFiles(_file, '*.patch')
         items.extend(stash.GetFiles(_file, '*.diff'))

--- a/oelint_adv/rule_base/rule_file_patch_upstreamstatus.py
+++ b/oelint_adv/rule_base/rule_file_patch_upstreamstatus.py
@@ -1,5 +1,5 @@
 import os
-from typing import List, Tuple
+from typing import List
 
 import regex  # noqa: I900
 from oelint_parser.cls_item import Variable
@@ -20,7 +20,7 @@ class FilePatchIsUpstreamStatus(Rule):
         # Find matching SRC_URI assignment
         return [x for x in items if x.VarValue.find(os.path.basename(path)) != -1]
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         patches = stash.GetFiles(_file, '*.patch')
         patches.extend(stash.GetFiles(_file, '*.diff'))

--- a/oelint_adv/rule_base/rule_file_patch_upstreamstatus.py
+++ b/oelint_adv/rule_base/rule_file_patch_upstreamstatus.py
@@ -20,7 +20,7 @@ class FilePatchIsUpstreamStatus(Rule):
         # Find matching SRC_URI assignment
         return [x for x in items if x.VarValue.find(os.path.basename(path)) != -1]
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         patches = stash.GetFiles(_file, '*.patch')
         patches.extend(stash.GetFiles(_file, '*.diff'))

--- a/oelint_adv/rule_base/rule_file_patch_upstreamstatus_occ.py
+++ b/oelint_adv/rule_base/rule_file_patch_upstreamstatus_occ.py
@@ -1,5 +1,5 @@
 import os
-from typing import List, Tuple
+from typing import List
 
 import regex  # noqa: I900
 from oelint_parser.cls_item import Variable
@@ -30,7 +30,7 @@ class FilePatchUpstreamStatusOccurance(Rule):
         # Find matching SRC_URI assignment
         return [x for x in items if x.VarValue.find(os.path.basename(path)) != -1]
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         patches = stash.GetFiles(_file, '*.patch')
         patches.extend(stash.GetFiles(_file, '*.diff'))

--- a/oelint_adv/rule_base/rule_file_patch_upstreamstatus_occ.py
+++ b/oelint_adv/rule_base/rule_file_patch_upstreamstatus_occ.py
@@ -30,7 +30,7 @@ class FilePatchUpstreamStatusOccurance(Rule):
         # Find matching SRC_URI assignment
         return [x for x in items if x.VarValue.find(os.path.basename(path)) != -1]
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         patches = stash.GetFiles(_file, '*.patch')
         patches.extend(stash.GetFiles(_file, '*.diff'))

--- a/oelint_adv/rule_base/rule_file_reqinc_norelpaths.py
+++ b/oelint_adv/rule_base/rule_file_reqinc_norelpaths.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Include
 from oelint_parser.cls_stash import Stash
@@ -12,7 +12,7 @@ class FileReqIncNoRelPaths(Rule):
                          severity='warning',
                          message='include or require statements should not use relative paths. Try using bbclasses instead')
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         for item in stash.GetItemsFor(filename=_file,
                                       classifier=Include.CLASSIFIER):

--- a/oelint_adv/rule_base/rule_file_reqinc_norelpaths.py
+++ b/oelint_adv/rule_base/rule_file_reqinc_norelpaths.py
@@ -12,7 +12,7 @@ class FileReqIncNoRelPaths(Rule):
                          severity='warning',
                          message='include or require statements should not use relative paths. Try using bbclasses instead')
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         for item in stash.GetItemsFor(filename=_file,
                                       classifier=Include.CLASSIFIER):

--- a/oelint_adv/rule_base/rule_file_require.py
+++ b/oelint_adv/rule_base/rule_file_require.py
@@ -13,7 +13,7 @@ class FileRequireNotFound(Rule):
                          severity='error',
                          message="'{FILE}' was not found")
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         for item in stash.GetItemsFor(filename=_file,
                                       classifier=Include.CLASSIFIER):

--- a/oelint_adv/rule_base/rule_file_require.py
+++ b/oelint_adv/rule_base/rule_file_require.py
@@ -1,5 +1,5 @@
 import os
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Include
 from oelint_parser.cls_stash import Stash
@@ -13,7 +13,7 @@ class FileRequireNotFound(Rule):
                          severity='error',
                          message="'{FILE}' was not found")
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         for item in stash.GetItemsFor(filename=_file,
                                       classifier=Include.CLASSIFIER):

--- a/oelint_adv/rule_base/rule_file_underscores.py
+++ b/oelint_adv/rule_base/rule_file_underscores.py
@@ -13,7 +13,7 @@ class FileNoSpaces(Rule):
                          message='FOO',
                          run_on=[Classification.RECIPE])
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         _basename, _ext = os.path.splitext(os.path.basename(_file))
         if _ext in ['.bb']:  # pragma: no cover

--- a/oelint_adv/rule_base/rule_file_underscores.py
+++ b/oelint_adv/rule_base/rule_file_underscores.py
@@ -1,5 +1,5 @@
 import os
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_stash import Stash
 
@@ -13,7 +13,7 @@ class FileNoSpaces(Rule):
                          message='FOO',
                          run_on=[Classification.RECIPE])
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         _basename, _ext = os.path.splitext(os.path.basename(_file))
         if _ext in ['.bb']:  # pragma: no cover

--- a/oelint_adv/rule_base/rule_func_spec.py
+++ b/oelint_adv/rule_base/rule_func_spec.py
@@ -14,7 +14,7 @@ class VarPnBpnUsage(Rule):
                          severity='error',
                          message="'{func}' is set specific to ['{b}'], but isn't known from PACKAGES, MACHINE, DISTRO")
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         items = stash.GetItemsFor(filename=_file, classifier=Function.CLASSIFIER,
                                   attribute=Function.ATTR_FUNCNAME)

--- a/oelint_adv/rule_base/rule_func_spec.py
+++ b/oelint_adv/rule_base/rule_func_spec.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Function, Variable
 from oelint_parser.cls_stash import Stash
@@ -14,7 +14,7 @@ class VarPnBpnUsage(Rule):
                          severity='error',
                          message="'{func}' is set specific to ['{b}'], but isn't known from PACKAGES, MACHINE, DISTRO")
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         items = stash.GetItemsFor(filename=_file, classifier=Function.CLASSIFIER,
                                   attribute=Function.ATTR_FUNCNAME)

--- a/oelint_adv/rule_base/rule_newline_consecutive.py
+++ b/oelint_adv/rule_base/rule_newline_consecutive.py
@@ -19,7 +19,7 @@ class NewLineConsecutive(Rule):
                 filename=_uniqname, nolink=True), key=lambda x: x.InFileLine)
         return res
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         for _, v in self.__getMatches(_file, stash).items():
             for index, value in enumerate(v):

--- a/oelint_adv/rule_base/rule_newline_consecutive.py
+++ b/oelint_adv/rule_base/rule_newline_consecutive.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_stash import Stash
 
@@ -19,7 +19,7 @@ class NewLineConsecutive(Rule):
                 filename=_uniqname, nolink=True), key=lambda x: x.InFileLine)
         return res
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         for _, v in self.__getMatches(_file, stash).items():
             for index, value in enumerate(v):

--- a/oelint_adv/rule_base/rule_newline_end.py
+++ b/oelint_adv/rule_base/rule_newline_end.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_stash import Stash
 
@@ -19,7 +19,7 @@ class NewLineEOF(Rule):
                 filename=_uniqname, nolink=True), key=lambda x: x.InFileLine)
         return res
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         for _, v in self.__getMatches(_file, stash).items():
             if not v[-1].Raw.endswith('\n'):

--- a/oelint_adv/rule_base/rule_newline_end.py
+++ b/oelint_adv/rule_base/rule_newline_end.py
@@ -19,7 +19,7 @@ class NewLineEOF(Rule):
                 filename=_uniqname, nolink=True), key=lambda x: x.InFileLine)
         return res
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         for _, v in self.__getMatches(_file, stash).items():
             if not v[-1].Raw.endswith('\n'):

--- a/oelint_adv/rule_base/rule_nospace_line_begin.py
+++ b/oelint_adv/rule_base/rule_nospace_line_begin.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Function, Item, PythonBlock
 from oelint_parser.cls_stash import Stash
@@ -20,7 +20,7 @@ class NoSpaceBeginningRule(Rule):
                 res.append(i)
         return res
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         for i in self.__getMatches(_file, stash):
             res += self.finding(i.Origin, i.InFileLine)

--- a/oelint_adv/rule_base/rule_nospace_line_begin.py
+++ b/oelint_adv/rule_base/rule_nospace_line_begin.py
@@ -20,7 +20,7 @@ class NoSpaceBeginningRule(Rule):
                 res.append(i)
         return res
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         for i in self.__getMatches(_file, stash):
             res += self.finding(i.Origin, i.InFileLine)

--- a/oelint_adv/rule_base/rule_nospace_line_cont.py
+++ b/oelint_adv/rule_base/rule_nospace_line_cont.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Comment, Item
 from oelint_parser.cls_stash import Stash
@@ -24,7 +24,7 @@ class NoSpaceRuleCont(Rule):
                     res.append(i)
         return res
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         for i in self.__getMatches(_file, stash):
             res += self.finding(i.Origin, i.InFileLine)

--- a/oelint_adv/rule_base/rule_nospace_line_cont.py
+++ b/oelint_adv/rule_base/rule_nospace_line_cont.py
@@ -24,7 +24,7 @@ class NoSpaceRuleCont(Rule):
                     res.append(i)
         return res
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         for i in self.__getMatches(_file, stash):
             res += self.finding(i.Origin, i.InFileLine)

--- a/oelint_adv/rule_base/rule_nospace_line_empty.py
+++ b/oelint_adv/rule_base/rule_nospace_line_empty.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Item
 from oelint_parser.cls_stash import Stash
@@ -20,7 +20,7 @@ class NoSpaceEmptyLineRule(Rule):
                 res.append(i)  # pragma: no cover
         return res
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         for i in self.__getMatches(_file, stash):
             res += self.finding(i.Origin, i.InFileLine)  # pragma: no cover

--- a/oelint_adv/rule_base/rule_nospace_line_empty.py
+++ b/oelint_adv/rule_base/rule_nospace_line_empty.py
@@ -20,7 +20,7 @@ class NoSpaceEmptyLineRule(Rule):
                 res.append(i)  # pragma: no cover
         return res
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         for i in self.__getMatches(_file, stash):
             res += self.finding(i.Origin, i.InFileLine)  # pragma: no cover

--- a/oelint_adv/rule_base/rule_nospace_line_end.py
+++ b/oelint_adv/rule_base/rule_nospace_line_end.py
@@ -24,7 +24,7 @@ class NoSpaceTrailingRule(Rule):
                 _linecnt += 1
         return res
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         for (i, line, blockoffset) in self.__getMatches(_file, stash):
             res += self.finding(i.Origin, line, blockoffset=blockoffset)

--- a/oelint_adv/rule_base/rule_nospace_line_end.py
+++ b/oelint_adv/rule_base/rule_nospace_line_end.py
@@ -24,7 +24,7 @@ class NoSpaceTrailingRule(Rule):
                 _linecnt += 1
         return res
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         for (i, line, blockoffset) in self.__getMatches(_file, stash):
             res += self.finding(i.Origin, line, blockoffset=blockoffset)

--- a/oelint_adv/rule_base/rule_notabs.py
+++ b/oelint_adv/rule_base/rule_notabs.py
@@ -21,7 +21,7 @@ class NoTabs(Rule):
                 res.append(i)
         return res
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         for i in self.__getMatches(_file, stash):
             res += self.finding(i.Origin, i.InFileLine)

--- a/oelint_adv/rule_base/rule_notabs.py
+++ b/oelint_adv/rule_base/rule_notabs.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Item
 from oelint_parser.cls_stash import Stash
@@ -21,7 +21,7 @@ class NoTabs(Rule):
                 res.append(i)
         return res
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         for i in self.__getMatches(_file, stash):
             res += self.finding(i.Origin, i.InFileLine)

--- a/oelint_adv/rule_base/rule_tasks_addnotaskbody.py
+++ b/oelint_adv/rule_base/rule_tasks_addnotaskbody.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Function, TaskAdd
 from oelint_parser.cls_stash import Stash
@@ -13,7 +13,7 @@ class TaskAddNoTaskBody(Rule):
                          severity='warning',
                          message="The added task '{FUNC}' is not existing or has no body")
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         for item in stash.GetItemsFor(filename=_file, classifier=TaskAdd.CLASSIFIER):
             if item.FuncName in CONSTANTS.FunctionsOrder:

--- a/oelint_adv/rule_base/rule_tasks_addnotaskbody.py
+++ b/oelint_adv/rule_base/rule_tasks_addnotaskbody.py
@@ -13,7 +13,7 @@ class TaskAddNoTaskBody(Rule):
                          severity='warning',
                          message="The added task '{FUNC}' is not existing or has no body")
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         for item in stash.GetItemsFor(filename=_file, classifier=TaskAdd.CLASSIFIER):
             if item.FuncName in CONSTANTS.FunctionsOrder:

--- a/oelint_adv/rule_base/rule_tasks_anon_python.py
+++ b/oelint_adv/rule_base/rule_tasks_anon_python.py
@@ -12,7 +12,7 @@ class TaskNoAnonPython(Rule):
                          severity='warning',
                          message='Avoid anonymous python functions as they are expensive and come with all sorts of side effects')
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         items = stash.GetItemsFor(
             filename=_file, classifier=Function.CLASSIFIER)

--- a/oelint_adv/rule_base/rule_tasks_anon_python.py
+++ b/oelint_adv/rule_base/rule_tasks_anon_python.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Function
 from oelint_parser.cls_stash import Stash
@@ -12,7 +12,7 @@ class TaskNoAnonPython(Rule):
                          severity='warning',
                          message='Avoid anonymous python functions as they are expensive and come with all sorts of side effects')
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         items = stash.GetItemsFor(
             filename=_file, classifier=Function.CLASSIFIER)

--- a/oelint_adv/rule_base/rule_tasks_customorder.py
+++ b/oelint_adv/rule_base/rule_tasks_customorder.py
@@ -20,7 +20,7 @@ class TaskCustomOrder(Rule):
             return [x for x in m.group('path').split('/') if x]
         return []  # pragma: no cover
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         items = stash.GetItemsFor(
             filename=_file, classifier=TaskAdd.CLASSIFIER)

--- a/oelint_adv/rule_base/rule_tasks_customorder.py
+++ b/oelint_adv/rule_base/rule_tasks_customorder.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from anytree import LoopError, Node
 from oelint_parser.cls_item import TaskAdd
@@ -20,7 +20,7 @@ class TaskCustomOrder(Rule):
             return [x for x in m.group('path').split('/') if x]
         return []  # pragma: no cover
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         items = stash.GetItemsFor(
             filename=_file, classifier=TaskAdd.CLASSIFIER)

--- a/oelint_adv/rule_base/rule_tasks_dash.py
+++ b/oelint_adv/rule_base/rule_tasks_dash.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Function, PythonBlock, TaskAdd, TaskDel
 from oelint_parser.cls_stash import Stash
@@ -12,7 +12,7 @@ class TaskDash(Rule):
                          severity='error',
                          message="Task '{FUNC}' shall not have '-' in its name")
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         for item in stash.GetItemsFor(filename=_file, classifier=(
                 TaskAdd.CLASSIFIER, Function.CLASSIFIER,

--- a/oelint_adv/rule_base/rule_tasks_dash.py
+++ b/oelint_adv/rule_base/rule_tasks_dash.py
@@ -12,7 +12,7 @@ class TaskDash(Rule):
                          severity='error',
                          message="Task '{FUNC}' shall not have '-' in its name")
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         for item in stash.GetItemsFor(filename=_file, classifier=(
                 TaskAdd.CLASSIFIER, Function.CLASSIFIER,

--- a/oelint_adv/rule_base/rule_tasks_doc_strings.py
+++ b/oelint_adv/rule_base/rule_tasks_doc_strings.py
@@ -13,7 +13,7 @@ class TaskDocStrings(Rule):
                          severity='info',
                          message="Every custom task should have a doc string set by task[doc] = '...'")
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         for item in stash.GetItemsFor(filename=_file, classifier=Function.CLASSIFIER):
             if item.FuncName in CONSTANTS.FunctionsKnown or item.FuncName in ['', 'anonymous', '__anonymous']:

--- a/oelint_adv/rule_base/rule_tasks_doc_strings.py
+++ b/oelint_adv/rule_base/rule_tasks_doc_strings.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import FlagAssignment, Function
 from oelint_parser.cls_stash import Stash
@@ -13,7 +13,7 @@ class TaskDocStrings(Rule):
                          severity='info',
                          message="Every custom task should have a doc string set by task[doc] = '...'")
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         for item in stash.GetItemsFor(filename=_file, classifier=Function.CLASSIFIER):
             if item.FuncName in CONSTANTS.FunctionsKnown or item.FuncName in ['', 'anonymous', '__anonymous']:

--- a/oelint_adv/rule_base/rule_tasks_heredocs.py
+++ b/oelint_adv/rule_base/rule_tasks_heredocs.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Function
 from oelint_parser.cls_stash import Stash
@@ -13,7 +13,7 @@ class TaskInstallNoCp(Rule):
                          severity='warning',
                          message='Usage of heredocs should be avoided. Use files instead')
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         items = stash.GetItemsFor(filename=_file, classifier=Function.CLASSIFIER,
                                   attribute=Function.ATTR_FUNCNAME)

--- a/oelint_adv/rule_base/rule_tasks_heredocs.py
+++ b/oelint_adv/rule_base/rule_tasks_heredocs.py
@@ -13,7 +13,7 @@ class TaskInstallNoCp(Rule):
                          severity='warning',
                          message='Usage of heredocs should be avoided. Use files instead')
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         items = stash.GetItemsFor(filename=_file, classifier=Function.CLASSIFIER,
                                   attribute=Function.ATTR_FUNCNAME)

--- a/oelint_adv/rule_base/rule_tasks_multiappends.py
+++ b/oelint_adv/rule_base/rule_tasks_multiappends.py
@@ -12,7 +12,7 @@ class TaskMultiFragments(Rule):
                          severity='info',
                          message='Multiple fragments of the same function in the same file should be merged')
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         _stash: List[Function] = stash.GetItemsFor(filename=_file, classifier=Function.CLASSIFIER)
         _known_matches = []

--- a/oelint_adv/rule_base/rule_tasks_multiappends.py
+++ b/oelint_adv/rule_base/rule_tasks_multiappends.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Function
 from oelint_parser.cls_stash import Stash
@@ -12,7 +12,7 @@ class TaskMultiFragments(Rule):
                          severity='info',
                          message='Multiple fragments of the same function in the same file should be merged')
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         _stash: List[Function] = stash.GetItemsFor(filename=_file, classifier=Function.CLASSIFIER)
         _known_matches = []

--- a/oelint_adv/rule_base/rule_tasks_network.py
+++ b/oelint_adv/rule_base/rule_tasks_network.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import FlagAssignment, Function
 from oelint_parser.cls_stash import Stash
@@ -14,7 +14,7 @@ class TaskNetwork(Rule):
                          message="Task '{FUNC}' uses the network flag, that can lead to unpredictable results",
                          valid_from_release='kirkstone')
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         task_names = {x.FuncName for x in stash.GetItemsFor(filename=_file, classifier=Function.CLASSIFIER)}
         task_names.update(CONSTANTS.FunctionsKnown)

--- a/oelint_adv/rule_base/rule_tasks_network.py
+++ b/oelint_adv/rule_base/rule_tasks_network.py
@@ -14,7 +14,7 @@ class TaskNetwork(Rule):
                          message="Task '{FUNC}' uses the network flag, that can lead to unpredictable results",
                          valid_from_release='kirkstone')
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         task_names = {x.FuncName for x in stash.GetItemsFor(filename=_file, classifier=Function.CLASSIFIER)}
         task_names.update(CONSTANTS.FunctionsKnown)

--- a/oelint_adv/rule_base/rule_tasks_no_cp.py
+++ b/oelint_adv/rule_base/rule_tasks_no_cp.py
@@ -13,7 +13,7 @@ class TaskInstallNoCp(Rule):
                          severity='error',
                          message="'cp' shall not be used in do_install. Use 'install'")
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         items: List[Function] = stash.GetItemsFor(filename=_file, classifier=Function.CLASSIFIER)
         for item in items:

--- a/oelint_adv/rule_base/rule_tasks_no_cp.py
+++ b/oelint_adv/rule_base/rule_tasks_no_cp.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Function
 from oelint_parser.cls_stash import Stash
@@ -13,7 +13,7 @@ class TaskInstallNoCp(Rule):
                          severity='error',
                          message="'cp' shall not be used in do_install. Use 'install'")
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         items: List[Function] = stash.GetItemsFor(filename=_file, classifier=Function.CLASSIFIER)
         for item in items:

--- a/oelint_adv/rule_base/rule_tasks_no_mkdir.py
+++ b/oelint_adv/rule_base/rule_tasks_no_mkdir.py
@@ -12,7 +12,7 @@ class TaskInstallNoMkdir(Rule):
                          severity='error',
                          message="'mkdir' shall not be used in do_install. Use 'install'")
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         items: List[Function] = stash.GetItemsFor(filename=_file, classifier=Function.CLASSIFIER)
         for item in items:

--- a/oelint_adv/rule_base/rule_tasks_no_mkdir.py
+++ b/oelint_adv/rule_base/rule_tasks_no_mkdir.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Function
 from oelint_parser.cls_stash import Stash
@@ -12,7 +12,7 @@ class TaskInstallNoMkdir(Rule):
                          severity='error',
                          message="'mkdir' shall not be used in do_install. Use 'install'")
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         items: List[Function] = stash.GetItemsFor(filename=_file, classifier=Function.CLASSIFIER)
         for item in items:

--- a/oelint_adv/rule_base/rule_tasks_nopython_prefix.py
+++ b/oelint_adv/rule_base/rule_tasks_nopython_prefix.py
@@ -1,6 +1,6 @@
 import ast
 import textwrap
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Function
 from oelint_parser.cls_stash import Stash
@@ -14,7 +14,7 @@ class TaskNoPythonPrefix(Rule):
                          severity='warning',
                          message="Tasks that don't contain valid python code (e.g. shell code), should not be prefixed with python in function header")
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         items: List[Function] = stash.GetItemsFor(filename=_file, classifier=Function.CLASSIFIER)
         for item in items:

--- a/oelint_adv/rule_base/rule_tasks_nopython_prefix.py
+++ b/oelint_adv/rule_base/rule_tasks_nopython_prefix.py
@@ -14,7 +14,7 @@ class TaskNoPythonPrefix(Rule):
                          severity='warning',
                          message="Tasks that don't contain valid python code (e.g. shell code), should not be prefixed with python in function header")
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         items: List[Function] = stash.GetItemsFor(filename=_file, classifier=Function.CLASSIFIER)
         for item in items:

--- a/oelint_adv/rule_base/rule_tasks_order.py
+++ b/oelint_adv/rule_base/rule_tasks_order.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Function
 from oelint_parser.cls_stash import Stash
@@ -14,7 +14,7 @@ class TaskOrder(Rule):
                          message='<FOO>',
                          appendix=CONSTANTS.FunctionsOrder)
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         _files = {item.Origin for item in stash.GetItemsFor(
             filename=_file, classifier=Function.CLASSIFIER)}

--- a/oelint_adv/rule_base/rule_tasks_order.py
+++ b/oelint_adv/rule_base/rule_tasks_order.py
@@ -14,7 +14,7 @@ class TaskOrder(Rule):
                          message='<FOO>',
                          appendix=CONSTANTS.FunctionsOrder)
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         _files = {item.Origin for item in stash.GetItemsFor(
             filename=_file, classifier=Function.CLASSIFIER)}

--- a/oelint_adv/rule_base/rule_tasks_python_prefix.py
+++ b/oelint_adv/rule_base/rule_tasks_python_prefix.py
@@ -14,7 +14,7 @@ class TaskPythonPrefix(Rule):
                          severity='warning',
                          message='Tasks containing python code, should be prefixed with python in function header')
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         items: List[Function] = stash.GetItemsFor(filename=_file, classifier=Function.CLASSIFIER)
         for item in items:

--- a/oelint_adv/rule_base/rule_tasks_python_prefix.py
+++ b/oelint_adv/rule_base/rule_tasks_python_prefix.py
@@ -1,6 +1,6 @@
 import ast
 import textwrap
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Function
 from oelint_parser.cls_stash import Stash
@@ -14,7 +14,7 @@ class TaskPythonPrefix(Rule):
                          severity='warning',
                          message='Tasks containing python code, should be prefixed with python in function header')
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         items: List[Function] = stash.GetItemsFor(filename=_file, classifier=Function.CLASSIFIER)
         for item in items:

--- a/oelint_adv/rule_base/rule_var_addpylib.py
+++ b/oelint_adv/rule_base/rule_var_addpylib.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_stash import Stash
 from oelint_parser.cls_item import AddPylib
@@ -13,7 +13,7 @@ class AddpyLib(Rule):
                          run_on=[Classification.BBCLASS, Classification.BBAPPEND, Classification.RECIPE],
                          message='addpylib is only valid in .conf files')
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         items_pylib: List[AddPylib] = stash.GetItemsFor(filename=_file, classifier=AddPylib.CLASSIFIER)
         for item in items_pylib:

--- a/oelint_adv/rule_base/rule_var_addpylib.py
+++ b/oelint_adv/rule_base/rule_var_addpylib.py
@@ -13,7 +13,7 @@ class AddpyLib(Rule):
                          run_on=[Classification.BBCLASS, Classification.BBAPPEND, Classification.RECIPE],
                          message='addpylib is only valid in .conf files')
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         items_pylib: List[AddPylib] = stash.GetItemsFor(filename=_file, classifier=AddPylib.CLASSIFIER)
         for item in items_pylib:

--- a/oelint_adv/rule_base/rule_var_appendop.py
+++ b/oelint_adv/rule_base/rule_var_appendop.py
@@ -12,7 +12,7 @@ class VarAppendOperation(Rule):
                          severity='error',
                          message="Use '{a}' instead of '{b}' as it overwrites '{c}'")
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         items: List[Variable] = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER)
         for name in {x.VarName for x in items}:

--- a/oelint_adv/rule_base/rule_var_appendop.py
+++ b/oelint_adv/rule_base/rule_var_appendop.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Variable
 from oelint_parser.cls_stash import Stash
@@ -12,7 +12,7 @@ class VarAppendOperation(Rule):
                          severity='error',
                          message="Use '{a}' instead of '{b}' as it overwrites '{c}'")
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         items: List[Variable] = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER)
         for name in {x.VarName for x in items}:

--- a/oelint_adv/rule_base/rule_var_autorev.py
+++ b/oelint_adv/rule_base/rule_var_autorev.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Variable
 from oelint_parser.cls_stash import Stash
@@ -12,7 +12,7 @@ class VarAutorev(Rule):
                          severity='warning',
                          message="The usage of 'AUTOREV' for SRCREV leads to not reproducible builds")
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         items: List[Variable] = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
                                                   attribute=Variable.ATTR_VAR)

--- a/oelint_adv/rule_base/rule_var_autorev.py
+++ b/oelint_adv/rule_base/rule_var_autorev.py
@@ -12,7 +12,7 @@ class VarAutorev(Rule):
                          severity='warning',
                          message="The usage of 'AUTOREV' for SRCREV leads to not reproducible builds")
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         items: List[Variable] = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
                                                   attribute=Variable.ATTR_VAR)

--- a/oelint_adv/rule_base/rule_var_bbvars.py
+++ b/oelint_adv/rule_base/rule_var_bbvars.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Variable, Inherit
 from oelint_parser.cls_stash import Stash
@@ -15,7 +15,7 @@ class VarQuoted(Rule):
                          message="Variable '{VAR}' should be set on a disto/layer or local.conf level, not in a recipe",
                          appendix=CONSTANTS.GetByPath('variables/protected'))
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         items: List[Variable] = stash.GetItemsFor(filename=_file,
                                                   classifier=Variable.CLASSIFIER,

--- a/oelint_adv/rule_base/rule_var_bbvars.py
+++ b/oelint_adv/rule_base/rule_var_bbvars.py
@@ -15,7 +15,7 @@ class VarQuoted(Rule):
                          message="Variable '{VAR}' should be set on a disto/layer or local.conf level, not in a recipe",
                          appendix=CONSTANTS.GetByPath('variables/protected'))
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         items: List[Variable] = stash.GetItemsFor(filename=_file,
                                                   classifier=Variable.CLASSIFIER,

--- a/oelint_adv/rule_base/rule_var_bugtracker_url.py
+++ b/oelint_adv/rule_base/rule_var_bugtracker_url.py
@@ -12,7 +12,7 @@ class VarBugtrackerIsUrl(Rule):
                          severity='warning',
                          message="'BUGTRACKER' should be an URL")
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         items: List[Variable] = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
                                                   attribute=Variable.ATTR_VAR, attributeValue='BUGTRACKER')

--- a/oelint_adv/rule_base/rule_var_bugtracker_url.py
+++ b/oelint_adv/rule_base/rule_var_bugtracker_url.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Variable
 from oelint_parser.cls_stash import Stash
@@ -12,7 +12,7 @@ class VarBugtrackerIsUrl(Rule):
                          severity='warning',
                          message="'BUGTRACKER' should be an URL")
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         items: List[Variable] = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
                                                   attribute=Variable.ATTR_VAR, attributeValue='BUGTRACKER')

--- a/oelint_adv/rule_base/rule_var_depends_append.py
+++ b/oelint_adv/rule_base/rule_var_depends_append.py
@@ -12,7 +12,7 @@ class VarDependsAppend(Rule):
                          severity='error',
                          message='DEPENDS should only be appended, not overwritten after an include or inherit')
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         items: List[Variable] = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
                                                   attribute=Variable.ATTR_VAR, attributeValue='DEPENDS')

--- a/oelint_adv/rule_base/rule_var_depends_append.py
+++ b/oelint_adv/rule_base/rule_var_depends_append.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Include, Inherit, Item, Variable
 from oelint_parser.cls_stash import Stash
@@ -12,7 +12,7 @@ class VarDependsAppend(Rule):
                          severity='error',
                          message='DEPENDS should only be appended, not overwritten after an include or inherit')
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         items: List[Variable] = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
                                                   attribute=Variable.ATTR_VAR, attributeValue='DEPENDS')

--- a/oelint_adv/rule_base/rule_var_depends_class.py
+++ b/oelint_adv/rule_base/rule_var_depends_class.py
@@ -14,7 +14,7 @@ class VarDependsClass(Rule):
                          run_on=[Classification.RECIPE, Classification.BBAPPEND],
                          message="{org} should be {patched} as it's a {class_} only recipe")
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         items: List[Variable] = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
                                                   attribute=Variable.ATTR_VAR, attributeValue='DEPENDS')

--- a/oelint_adv/rule_base/rule_var_depends_class.py
+++ b/oelint_adv/rule_base/rule_var_depends_class.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Inherit, Variable
 from oelint_parser.cls_stash import Stash
@@ -14,7 +14,7 @@ class VarDependsClass(Rule):
                          run_on=[Classification.RECIPE, Classification.BBAPPEND],
                          message="{org} should be {patched} as it's a {class_} only recipe")
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         items: List[Variable] = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
                                                   attribute=Variable.ATTR_VAR, attributeValue='DEPENDS')

--- a/oelint_adv/rule_base/rule_var_depends_ordered.py
+++ b/oelint_adv/rule_base/rule_var_depends_ordered.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Item, Variable
 from oelint_parser.cls_stash import Stash
@@ -23,7 +23,7 @@ class VarDependsOrdered(Rule):
             return False
         return True
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         items: List[Variable] = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
                                                   attribute=Variable.ATTR_VAR)

--- a/oelint_adv/rule_base/rule_var_depends_ordered.py
+++ b/oelint_adv/rule_base/rule_var_depends_ordered.py
@@ -23,7 +23,7 @@ class VarDependsOrdered(Rule):
             return False
         return True
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         items: List[Variable] = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
                                                   attribute=Variable.ATTR_VAR)

--- a/oelint_adv/rule_base/rule_var_descriptionsame.py
+++ b/oelint_adv/rule_base/rule_var_descriptionsame.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Variable
 from oelint_parser.cls_stash import Stash
@@ -12,7 +12,7 @@ class VarDescSame(Rule):
                          severity='warning',
                          message="'DESCRIPTION' is the same a 'SUMMARY' - it can be removed then")
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         items: List[Variable] = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
                                                   attribute=Variable.ATTR_VAR, attributeValue='DESCRIPTION')

--- a/oelint_adv/rule_base/rule_var_descriptionsame.py
+++ b/oelint_adv/rule_base/rule_var_descriptionsame.py
@@ -12,7 +12,7 @@ class VarDescSame(Rule):
                          severity='warning',
                          message="'DESCRIPTION' is the same a 'SUMMARY' - it can be removed then")
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         items: List[Variable] = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
                                                   attribute=Variable.ATTR_VAR, attributeValue='DESCRIPTION')

--- a/oelint_adv/rule_base/rule_var_descriptiontooshort.py
+++ b/oelint_adv/rule_base/rule_var_descriptiontooshort.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Variable
 from oelint_parser.cls_stash import Stash
@@ -12,7 +12,7 @@ class VarDescSameTooBrief(Rule):
                          severity='warning',
                          message="'DESCRIPTION' is shorter than 'SUMMARY'")
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         items: List[Variable] = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
                                                   attribute=Variable.ATTR_VAR, attributeValue='DESCRIPTION')

--- a/oelint_adv/rule_base/rule_var_descriptiontooshort.py
+++ b/oelint_adv/rule_base/rule_var_descriptiontooshort.py
@@ -12,7 +12,7 @@ class VarDescSameTooBrief(Rule):
                          severity='warning',
                          message="'DESCRIPTION' is shorter than 'SUMMARY'")
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         items: List[Variable] = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
                                                   attribute=Variable.ATTR_VAR, attributeValue='DESCRIPTION')

--- a/oelint_adv/rule_base/rule_var_distrofeatoptout.py
+++ b/oelint_adv/rule_base/rule_var_distrofeatoptout.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Variable
 from oelint_parser.cls_stash import Stash
@@ -14,7 +14,7 @@ class VarDistroFeatureOptOut(Rule):
                          run_on=[Classification.DISTROCONF],
                          valid_from_release='wrynose')
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         items: List[Variable] = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
                                                   attribute=Variable.ATTR_VAR, attributeValue='DISTRO_FEATURES')

--- a/oelint_adv/rule_base/rule_var_distrofeatoptout.py
+++ b/oelint_adv/rule_base/rule_var_distrofeatoptout.py
@@ -14,7 +14,7 @@ class VarDistroFeatureOptOut(Rule):
                          run_on=[Classification.DISTROCONF],
                          valid_from_release='wrynose')
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         items: List[Variable] = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
                                                   attribute=Variable.ATTR_VAR, attributeValue='DISTRO_FEATURES')

--- a/oelint_adv/rule_base/rule_var_doublemodify.py
+++ b/oelint_adv/rule_base/rule_var_doublemodify.py
@@ -12,7 +12,7 @@ class VarSectionLowercase(Rule):
                          severity='error',
                          message='Multiple modifiers of append/prepend/remove/+= found in one operation')
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         items: List[Variable] = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER)
         for i in items:

--- a/oelint_adv/rule_base/rule_var_doublemodify.py
+++ b/oelint_adv/rule_base/rule_var_doublemodify.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Variable
 from oelint_parser.cls_stash import Stash
@@ -12,7 +12,7 @@ class VarSectionLowercase(Rule):
                          severity='error',
                          message='Multiple modifiers of append/prepend/remove/+= found in one operation')
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         items: List[Variable] = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER)
         for i in items:

--- a/oelint_adv/rule_base/rule_var_duplicates.py
+++ b/oelint_adv/rule_base/rule_var_duplicates.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Variable
 from oelint_parser.cls_stash import Stash
@@ -14,7 +14,7 @@ class VarDuplicates(Rule):
                          severity='warning',
                          message='<FOO>')
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         for c in ['DEPENDS', 'RDEPENDS']:
             items: List[Variable] = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,

--- a/oelint_adv/rule_base/rule_var_duplicates.py
+++ b/oelint_adv/rule_base/rule_var_duplicates.py
@@ -14,7 +14,7 @@ class VarDuplicates(Rule):
                          severity='warning',
                          message='<FOO>')
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         for c in ['DEPENDS', 'RDEPENDS']:
             items: List[Variable] = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,

--- a/oelint_adv/rule_base/rule_var_filesextrapaths.py
+++ b/oelint_adv/rule_base/rule_var_filesextrapaths.py
@@ -14,7 +14,7 @@ class VarBugtrackerIsUrl(Rule):
                                  Classification.LAYERCONF, Classification.MACHINECONF, Classification.RECIPE],
                          message="'FILESEXTRAPATHS' should be used only in a bbappend file")
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         items: List[Variable] = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
                                                   attribute=Variable.ATTR_VAR, attributeValue='FILESEXTRAPATHS')

--- a/oelint_adv/rule_base/rule_var_filesextrapaths.py
+++ b/oelint_adv/rule_base/rule_var_filesextrapaths.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Variable
 from oelint_parser.cls_stash import Stash
@@ -14,7 +14,7 @@ class VarBugtrackerIsUrl(Rule):
                                  Classification.LAYERCONF, Classification.MACHINECONF, Classification.RECIPE],
                          message="'FILESEXTRAPATHS' should be used only in a bbappend file")
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         items: List[Variable] = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
                                                   attribute=Variable.ATTR_VAR, attributeValue='FILESEXTRAPATHS')

--- a/oelint_adv/rule_base/rule_var_filesextrapathsop.py
+++ b/oelint_adv/rule_base/rule_var_filesextrapathsop.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Variable
 from oelint_parser.cls_stash import Stash
@@ -12,7 +12,7 @@ class VarBugtrackerIsUrl(Rule):
                          severity='error',
                          message="'FILESEXTRAPATHS' should only be used in combination with ' := '")
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         items: List[Variable] = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
                                                   attribute=Variable.ATTR_VAR, attributeValue='FILESEXTRAPATHS')

--- a/oelint_adv/rule_base/rule_var_filesextrapathsop.py
+++ b/oelint_adv/rule_base/rule_var_filesextrapathsop.py
@@ -12,7 +12,7 @@ class VarBugtrackerIsUrl(Rule):
                          severity='error',
                          message="'FILESEXTRAPATHS' should only be used in combination with ' := '")
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         items: List[Variable] = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
                                                   attribute=Variable.ATTR_VAR, attributeValue='FILESEXTRAPATHS')

--- a/oelint_adv/rule_base/rule_var_filesoverride.py
+++ b/oelint_adv/rule_base/rule_var_filesoverride.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Variable
 from oelint_parser.cls_stash import Stash
@@ -12,7 +12,7 @@ class VarFilesOverride(Rule):
                          severity='warning',
                          message="'{a}' should not be overridden")
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         items: List[Variable] = stash.GetItemsFor(
             filename=_file, classifier=Variable.CLASSIFIER, attribute=Variable.ATTR_VAR, attributeValue='FILES')

--- a/oelint_adv/rule_base/rule_var_filesoverride.py
+++ b/oelint_adv/rule_base/rule_var_filesoverride.py
@@ -12,7 +12,7 @@ class VarFilesOverride(Rule):
                          severity='warning',
                          message="'{a}' should not be overridden")
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         items: List[Variable] = stash.GetItemsFor(
             filename=_file, classifier=Variable.CLASSIFIER, attribute=Variable.ATTR_VAR, attributeValue='FILES')

--- a/oelint_adv/rule_base/rule_var_homepage.py
+++ b/oelint_adv/rule_base/rule_var_homepage.py
@@ -12,7 +12,7 @@ class VarHomepagePrefix(Rule):
                          severity='warning',
                          message="'HOMEPAGE' should start with 'http://' or 'https://'")
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         items: List[Variable] = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
                                                   attribute=Variable.ATTR_VAR, attributeValue='HOMEPAGE')

--- a/oelint_adv/rule_base/rule_var_homepage.py
+++ b/oelint_adv/rule_base/rule_var_homepage.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Variable
 from oelint_parser.cls_stash import Stash
@@ -12,7 +12,7 @@ class VarHomepagePrefix(Rule):
                          severity='warning',
                          message="'HOMEPAGE' should start with 'http://' or 'https://'")
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         items: List[Variable] = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
                                                   attribute=Variable.ATTR_VAR, attributeValue='HOMEPAGE')

--- a/oelint_adv/rule_base/rule_var_homepageping.py
+++ b/oelint_adv/rule_base/rule_var_homepageping.py
@@ -14,7 +14,7 @@ class VarHomepagePing(Rule):
                          severity='warning',
                          message="'HOMEPAGE' isn't reachable")
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         items: List[Variable] = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
                                                   attribute=Variable.ATTR_VAR, attributeValue='HOMEPAGE')

--- a/oelint_adv/rule_base/rule_var_homepageping.py
+++ b/oelint_adv/rule_base/rule_var_homepageping.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
@@ -14,7 +14,7 @@ class VarHomepagePing(Rule):
                          severity='warning',
                          message="'HOMEPAGE' isn't reachable")
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         items: List[Variable] = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
                                                   attribute=Variable.ATTR_VAR, attributeValue='HOMEPAGE')

--- a/oelint_adv/rule_base/rule_var_imagefeatures_bad.py
+++ b/oelint_adv/rule_base/rule_var_imagefeatures_bad.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Variable
 from oelint_parser.cls_stash import Stash
@@ -27,7 +27,7 @@ class ImageFeaturesBad(Rule):
                          message="{var} contains '{feature}', {reason}",
                          appendix=list(self._map.keys()))
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         for item in stash.GetItemsFor(filename=_file,
                                       classifier=Variable.CLASSIFIER,

--- a/oelint_adv/rule_base/rule_var_imagefeatures_bad.py
+++ b/oelint_adv/rule_base/rule_var_imagefeatures_bad.py
@@ -27,7 +27,7 @@ class ImageFeaturesBad(Rule):
                          message="{var} contains '{feature}', {reason}",
                          appendix=list(self._map.keys()))
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         for item in stash.GetItemsFor(filename=_file,
                                       classifier=Variable.CLASSIFIER,

--- a/oelint_adv/rule_base/rule_var_inconsspaces.py
+++ b/oelint_adv/rule_base/rule_var_inconsspaces.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Variable
 from oelint_parser.cls_stash import Stash
@@ -12,7 +12,7 @@ class VarInconSpaces(Rule):
                          severity='error',
                          message='<FOO>')
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         items: List[Variable] = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER)
         for i in items:

--- a/oelint_adv/rule_base/rule_var_inconsspaces.py
+++ b/oelint_adv/rule_base/rule_var_inconsspaces.py
@@ -12,7 +12,7 @@ class VarInconSpaces(Rule):
                          severity='error',
                          message='<FOO>')
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         items: List[Variable] = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER)
         for i in items:

--- a/oelint_adv/rule_base/rule_var_insaneskip.py
+++ b/oelint_adv/rule_base/rule_var_insaneskip.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Variable
 from oelint_parser.cls_stash import Stash
@@ -12,7 +12,7 @@ class VarInsaneSkip(Rule):
                          severity='error',
                          message='INSANE_SKIP should be avoided at any cost')
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         items: List[Variable] = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
                                                   attribute=Variable.ATTR_VAR, attributeValue='INSANE_SKIP')

--- a/oelint_adv/rule_base/rule_var_insaneskip.py
+++ b/oelint_adv/rule_base/rule_var_insaneskip.py
@@ -12,7 +12,7 @@ class VarInsaneSkip(Rule):
                          severity='error',
                          message='INSANE_SKIP should be avoided at any cost')
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         items: List[Variable] = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
                                                   attribute=Variable.ATTR_VAR, attributeValue='INSANE_SKIP')

--- a/oelint_adv/rule_base/rule_var_license_remote.py
+++ b/oelint_adv/rule_base/rule_var_license_remote.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Variable
 from oelint_parser.cls_stash import Stash
@@ -12,7 +12,7 @@ class VarLicenseRemoteFile(Rule):
                          severity='warning',
                          message='License-File should be a remote file')
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         _items: List[Variable] = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
                                                    attribute=Variable.ATTR_VAR, attributeValue='LIC_FILES_CHKSUM')

--- a/oelint_adv/rule_base/rule_var_license_remote.py
+++ b/oelint_adv/rule_base/rule_var_license_remote.py
@@ -12,7 +12,7 @@ class VarLicenseRemoteFile(Rule):
                          severity='warning',
                          message='License-File should be a remote file')
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         _items: List[Variable] = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
                                                    attribute=Variable.ATTR_VAR, attributeValue='LIC_FILES_CHKSUM')

--- a/oelint_adv/rule_base/rule_var_license_spdx.py
+++ b/oelint_adv/rule_base/rule_var_license_spdx.py
@@ -12,7 +12,7 @@ class LicenseSPDX(Rule):
                          severity='warning',
                          message='LICENSE is not a valid OpenEmbedded SPDX expression')
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         items = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
                                   attribute=Variable.ATTR_VAR, attributeValue='LICENSE')

--- a/oelint_adv/rule_base/rule_var_license_spdx.py
+++ b/oelint_adv/rule_base/rule_var_license_spdx.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Variable
 from oelint_parser.cls_stash import Stash
@@ -12,7 +12,7 @@ class LicenseSPDX(Rule):
                          severity='warning',
                          message='LICENSE is not a valid OpenEmbedded SPDX expression')
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         items = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
                                   attribute=Variable.ATTR_VAR, attributeValue='LICENSE')

--- a/oelint_adv/rule_base/rule_var_licfileprefix.py
+++ b/oelint_adv/rule_base/rule_var_licfileprefix.py
@@ -1,5 +1,5 @@
 import os
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Variable
 from oelint_parser.cls_stash import Stash
@@ -25,7 +25,7 @@ class VarLicFilePrefix(Rule):
                     res.append(i)
         return res
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         for i in self.__getMatches(_file, stash):
             res += self.finding(i.Origin, i.InFileLine,

--- a/oelint_adv/rule_base/rule_var_licfileprefix.py
+++ b/oelint_adv/rule_base/rule_var_licfileprefix.py
@@ -25,7 +25,7 @@ class VarLicFilePrefix(Rule):
                     res.append(i)
         return res
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         for i in self.__getMatches(_file, stash):
             res += self.finding(i.Origin, i.InFileLine,

--- a/oelint_adv/rule_base/rule_var_machinefeatoptout.py
+++ b/oelint_adv/rule_base/rule_var_machinefeatoptout.py
@@ -14,7 +14,7 @@ class VarMachineFeatureOptOut(Rule):
                          run_on=[Classification.MACHINECONF],
                          valid_from_release='wrynose')
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         items: List[Variable] = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
                                                   attribute=Variable.ATTR_VAR, attributeValue='MACHINE_FEATURES')

--- a/oelint_adv/rule_base/rule_var_machinefeatoptout.py
+++ b/oelint_adv/rule_base/rule_var_machinefeatoptout.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Variable
 from oelint_parser.cls_stash import Stash
@@ -14,7 +14,7 @@ class VarMachineFeatureOptOut(Rule):
                          run_on=[Classification.MACHINECONF],
                          valid_from_release='wrynose')
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         items: List[Variable] = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
                                                   attribute=Variable.ATTR_VAR, attributeValue='MACHINE_FEATURES')

--- a/oelint_adv/rule_base/rule_var_misspell.py
+++ b/oelint_adv/rule_base/rule_var_misspell.py
@@ -1,7 +1,7 @@
 import os
 from difflib import SequenceMatcher
 import functools
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import FlagAssignment, Function, Item, Variable
 from oelint_parser.cls_stash import Stash
@@ -53,7 +53,7 @@ class VarMisspell(Rule):
 
         return self.__collected_var
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
 
         _all: List[Item] = stash.GetItemsFor(filename=_file)

--- a/oelint_adv/rule_base/rule_var_misspell.py
+++ b/oelint_adv/rule_base/rule_var_misspell.py
@@ -53,7 +53,7 @@ class VarMisspell(Rule):
 
         return self.__collected_var
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
 
         _all: List[Item] = stash.GetItemsFor(filename=_file)

--- a/oelint_adv/rule_base/rule_var_multilineindent.py
+++ b/oelint_adv/rule_base/rule_var_multilineindent.py
@@ -36,7 +36,7 @@ class VarMultiLineIndent(Rule):
 
         return (last_line_indent, non_empty_line_indent, _map)
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         items: List[Variable] = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER)
         for i in items:

--- a/oelint_adv/rule_base/rule_var_multilineindent.py
+++ b/oelint_adv/rule_base/rule_var_multilineindent.py
@@ -36,7 +36,7 @@ class VarMultiLineIndent(Rule):
 
         return (last_line_indent, non_empty_line_indent, _map)
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         items: List[Variable] = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER)
         for i in items:

--- a/oelint_adv/rule_base/rule_var_notneededspace.py
+++ b/oelint_adv/rule_base/rule_var_notneededspace.py
@@ -22,7 +22,7 @@ class VarSectionLowercase(Rule):
                 res.append(i)
         return res
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         for i in self.__getMatches(_file, stash):
             res += self.finding(i.Origin, i.InFileLine)

--- a/oelint_adv/rule_base/rule_var_notneededspace.py
+++ b/oelint_adv/rule_base/rule_var_notneededspace.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Variable
 from oelint_parser.cls_stash import Stash
@@ -22,7 +22,7 @@ class VarSectionLowercase(Rule):
                 res.append(i)
         return res
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         for i in self.__getMatches(_file, stash):
             res += self.finding(i.Origin, i.InFileLine)

--- a/oelint_adv/rule_base/rule_var_override_append.py
+++ b/oelint_adv/rule_base/rule_var_override_append.py
@@ -106,7 +106,7 @@ class VarOverrideAppend(Rule):
 
         return res
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         for i, extra_check, _ in self.__getMatches(_file, stash):
             res += self.finding(

--- a/oelint_adv/rule_base/rule_var_override_append.py
+++ b/oelint_adv/rule_base/rule_var_override_append.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Variable
 from oelint_parser.cls_stash import Stash
@@ -106,7 +106,7 @@ class VarOverrideAppend(Rule):
 
         return res
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         for i, extra_check, _ in self.__getMatches(_file, stash):
             res += self.finding(

--- a/oelint_adv/rule_base/rule_var_p_usage.py
+++ b/oelint_adv/rule_base/rule_var_p_usage.py
@@ -26,7 +26,7 @@ class VarPnBpnUsage(Rule):
                     res.append(i)
         return res
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         for i in self.__getMatches(_file, stash):
             res += self.finding(i.Origin, i.InFileLine)

--- a/oelint_adv/rule_base/rule_var_p_usage.py
+++ b/oelint_adv/rule_base/rule_var_p_usage.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Variable
 from oelint_parser.cls_stash import Stash
@@ -26,7 +26,7 @@ class VarPnBpnUsage(Rule):
                     res.append(i)
         return res
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         for i in self.__getMatches(_file, stash):
             res += self.finding(i.Origin, i.InFileLine)

--- a/oelint_adv/rule_base/rule_var_pkgfunc_dusage.py
+++ b/oelint_adv/rule_base/rule_var_pkgfunc_dusage.py
@@ -29,7 +29,7 @@ class VarDUsageInPkgfunc(Rule):
                 res.append(i)
         return res
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         for i in self.__getMatches(_file, stash):
             res += self.finding(i.Origin, i.InFileLine, override_msg=self.Msg.format(func=i.FuncName))

--- a/oelint_adv/rule_base/rule_var_pkgfunc_dusage.py
+++ b/oelint_adv/rule_base/rule_var_pkgfunc_dusage.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Function
 from oelint_parser.cls_stash import Stash
@@ -29,7 +29,7 @@ class VarDUsageInPkgfunc(Rule):
                 res.append(i)
         return res
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         for i in self.__getMatches(_file, stash):
             res += self.finding(i.Origin, i.InFileLine, override_msg=self.Msg.format(func=i.FuncName))

--- a/oelint_adv/rule_base/rule_var_pkgspecific.py
+++ b/oelint_adv/rule_base/rule_var_pkgspecific.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Variable
 from oelint_parser.cls_stash import Stash
@@ -15,7 +15,7 @@ class VarPkgSpecific(Rule):
                          message='Variable {VAR} is package-specific and therefore it should be {VAR}{DEL}<known package name>',
                          appendix=self.needles)
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
 
         if self.is_lone_append(stash, _file):

--- a/oelint_adv/rule_base/rule_var_pkgspecific.py
+++ b/oelint_adv/rule_base/rule_var_pkgspecific.py
@@ -15,7 +15,7 @@ class VarPkgSpecific(Rule):
                          message='Variable {VAR} is package-specific and therefore it should be {VAR}{DEL}<known package name>',
                          appendix=self.needles)
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
 
         if self.is_lone_append(stash, _file):

--- a/oelint_adv/rule_base/rule_var_pn_usage.py
+++ b/oelint_adv/rule_base/rule_var_pn_usage.py
@@ -23,7 +23,7 @@ class VarPnBpnUsage(Rule):
                     res.append(i)
         return res
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         for i in self.__getMatches(_file, stash):
             res += self.finding(i.Origin, i.InFileLine)

--- a/oelint_adv/rule_base/rule_var_pn_usage.py
+++ b/oelint_adv/rule_base/rule_var_pn_usage.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Variable
 from oelint_parser.cls_stash import Stash
@@ -23,7 +23,7 @@ class VarPnBpnUsage(Rule):
                     res.append(i)
         return res
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         for i in self.__getMatches(_file, stash):
             res += self.finding(i.Origin, i.InFileLine)

--- a/oelint_adv/rule_base/rule_var_pn_usage_discouraged.py
+++ b/oelint_adv/rule_base/rule_var_pn_usage_discouraged.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Variable
 from oelint_parser.cls_stash import Stash
@@ -12,7 +12,7 @@ class VarPnUsageDiscouraged(Rule):
                          severity='warning',
                          message="Variable shouldn't contain ${PN} or ${BPN}")
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         needles = ['SUMMARY', 'HOMEPAGE', 'BUGTRACKER', 'DESCRIPTION']
         items: List[Variable] = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,

--- a/oelint_adv/rule_base/rule_var_pn_usage_discouraged.py
+++ b/oelint_adv/rule_base/rule_var_pn_usage_discouraged.py
@@ -12,7 +12,7 @@ class VarPnUsageDiscouraged(Rule):
                          severity='warning',
                          message="Variable shouldn't contain ${PN} or ${BPN}")
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         needles = ['SUMMARY', 'HOMEPAGE', 'BUGTRACKER', 'DESCRIPTION']
         items: List[Variable] = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,

--- a/oelint_adv/rule_base/rule_var_python_pn_usage.py
+++ b/oelint_adv/rule_base/rule_var_python_pn_usage.py
@@ -35,7 +35,7 @@ class VarPythonPnUsage(Rule):
                 res.append((i, needles))
         return res
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         for i in self.__getMatches(_file, stash):
             item, _ = i

--- a/oelint_adv/rule_base/rule_var_python_pn_usage.py
+++ b/oelint_adv/rule_base/rule_var_python_pn_usage.py
@@ -35,7 +35,7 @@ class VarPythonPnUsage(Rule):
                 res.append((i, needles))
         return res
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         for i in self.__getMatches(_file, stash):
             item, _ = i

--- a/oelint_adv/rule_base/rule_var_python_rdepends.py
+++ b/oelint_adv/rule_base/rule_var_python_rdepends.py
@@ -15,7 +15,7 @@ class VarPythonRdepends(Rule):
                          message='{var} installs the entire python ecosystem. Most likely you only want sub packages like {var}-core',
                          valid_from_release='scarthgap')
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         items: List[Variable] = stash.GetItemsFor(filename=_file,
                                                   classifier=Variable.CLASSIFIER,

--- a/oelint_adv/rule_base/rule_var_python_rdepends.py
+++ b/oelint_adv/rule_base/rule_var_python_rdepends.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Variable
 from oelint_parser.cls_stash import Stash
@@ -15,7 +15,7 @@ class VarPythonRdepends(Rule):
                          message='{var} installs the entire python ecosystem. Most likely you only want sub packages like {var}-core',
                          valid_from_release='scarthgap')
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         items: List[Variable] = stash.GetItemsFor(filename=_file,
                                                   classifier=Variable.CLASSIFIER,

--- a/oelint_adv/rule_base/rule_var_quoted.py
+++ b/oelint_adv/rule_base/rule_var_quoted.py
@@ -12,7 +12,7 @@ class VarQuoted(Rule):
                          severity='error',
                          message='Variable value should be quoted')
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         items: List[Variable] = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER)
         for i in items:

--- a/oelint_adv/rule_base/rule_var_quoted.py
+++ b/oelint_adv/rule_base/rule_var_quoted.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Variable
 from oelint_parser.cls_stash import Stash
@@ -12,7 +12,7 @@ class VarQuoted(Rule):
                          severity='error',
                          message='Variable value should be quoted')
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         items: List[Variable] = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER)
         for i in items:

--- a/oelint_adv/rule_base/rule_var_renamed.py
+++ b/oelint_adv/rule_base/rule_var_renamed.py
@@ -22,7 +22,7 @@ class VarsRenamed(Rule):
                                                   attributeValue=list(self._map.keys()))
         return items
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         for i in self.__getMatches(_file, stash):
             message = self._map[i.VarName]

--- a/oelint_adv/rule_base/rule_var_renamed.py
+++ b/oelint_adv/rule_base/rule_var_renamed.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Variable
 from oelint_parser.cls_stash import Stash
@@ -22,7 +22,7 @@ class VarsRenamed(Rule):
                                                   attributeValue=list(self._map.keys()))
         return items
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         for i in self.__getMatches(_file, stash):
             message = self._map[i.VarName]

--- a/oelint_adv/rule_base/rule_var_rootfscmd.py
+++ b/oelint_adv/rule_base/rule_var_rootfscmd.py
@@ -12,7 +12,7 @@ class VarRootfsPostprocessCommand(Rule):
                          severity='warning',
                          message='ROOTFS_POSTPROCESS_COMMAND should not have trailing blanks')
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         items: List[Variable] = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
                                                   attribute=Variable.ATTR_VAR, attributeValue='ROOTFS_POSTPROCESS_COMMAND')

--- a/oelint_adv/rule_base/rule_var_rootfscmd.py
+++ b/oelint_adv/rule_base/rule_var_rootfscmd.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Variable
 from oelint_parser.cls_stash import Stash
@@ -12,7 +12,7 @@ class VarRootfsPostprocessCommand(Rule):
                          severity='warning',
                          message='ROOTFS_POSTPROCESS_COMMAND should not have trailing blanks')
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         items: List[Variable] = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
                                                   attribute=Variable.ATTR_VAR, attributeValue='ROOTFS_POSTPROCESS_COMMAND')

--- a/oelint_adv/rule_base/rule_var_section_lowercase.py
+++ b/oelint_adv/rule_base/rule_var_section_lowercase.py
@@ -21,7 +21,7 @@ class VarSectionLowercase(Rule):
                 res.append(i)
         return res
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         for i in self.__getMatches(_file, stash):
             res += self.finding(i.Origin, i.InFileLine)

--- a/oelint_adv/rule_base/rule_var_section_lowercase.py
+++ b/oelint_adv/rule_base/rule_var_section_lowercase.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Variable
 from oelint_parser.cls_stash import Stash
@@ -21,7 +21,7 @@ class VarSectionLowercase(Rule):
                 res.append(i)
         return res
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         for i in self.__getMatches(_file, stash):
             res += self.finding(i.Origin, i.InFileLine)

--- a/oelint_adv/rule_base/rule_var_spaces_assignment.py
+++ b/oelint_adv/rule_base/rule_var_spaces_assignment.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import FlagAssignment, Variable
 from oelint_parser.cls_stash import Stash
@@ -12,7 +12,7 @@ class VarSpacesOnAssignment(Rule):
                          severity='warning',
                          message='Suggest spaces around assignment. E.g. \'FOO = "BAR"\'')
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         items: List[Variable] = stash.GetItemsFor(filename=_file, classifier=[Variable.CLASSIFIER, FlagAssignment.CLASSIFIER])
         for i in items:

--- a/oelint_adv/rule_base/rule_var_spaces_assignment.py
+++ b/oelint_adv/rule_base/rule_var_spaces_assignment.py
@@ -12,7 +12,7 @@ class VarSpacesOnAssignment(Rule):
                          severity='warning',
                          message='Suggest spaces around assignment. E.g. \'FOO = "BAR"\'')
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         items: List[Variable] = stash.GetItemsFor(filename=_file, classifier=[Variable.CLASSIFIER, FlagAssignment.CLASSIFIER])
         for i in items:

--- a/oelint_adv/rule_base/rule_var_spec.py
+++ b/oelint_adv/rule_base/rule_var_spec.py
@@ -15,7 +15,7 @@ class VarPnBpnUsage(Rule):
                          message="'{a}' is set specific to ['{b}'], but isn't known from PACKAGES, MACHINE, DISTRO or resources",
                          run_on=[Classification.RECIPE, Classification.BBCLASS])
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         items: List[Variable] = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER)
         _comp = ''.join(x.VarValueStripped for x in stash.Reduce(items, classifier=Variable.CLASSIFIER, attribute=Variable.ATTR_VAR,

--- a/oelint_adv/rule_base/rule_var_spec.py
+++ b/oelint_adv/rule_base/rule_var_spec.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Variable
 from oelint_parser.cls_stash import Stash
@@ -15,7 +15,7 @@ class VarPnBpnUsage(Rule):
                          message="'{a}' is set specific to ['{b}'], but isn't known from PACKAGES, MACHINE, DISTRO or resources",
                          run_on=[Classification.RECIPE, Classification.BBCLASS])
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         items: List[Variable] = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER)
         _comp = ''.join(x.VarValueStripped for x in stash.Reduce(items, classifier=Variable.CLASSIFIER, attribute=Variable.ATTR_VAR,

--- a/oelint_adv/rule_base/rule_var_spec_non_core.py
+++ b/oelint_adv/rule_base/rule_var_spec_non_core.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Variable, Function
 from oelint_parser.cls_stash import Stash
@@ -14,7 +14,7 @@ class VarSpecNonCore(Rule):
                          message="'{a}' need to be specific to a custom MACHINE or DISTRO to be Yocto project compliant",
                          run_on=[Classification.BBAPPEND])
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         self._core_constants = Constants(self._state.core_mod_ref)
 
         res = []

--- a/oelint_adv/rule_base/rule_var_spec_non_core.py
+++ b/oelint_adv/rule_base/rule_var_spec_non_core.py
@@ -14,7 +14,7 @@ class VarSpecNonCore(Rule):
                          message="'{a}' need to be specific to a custom MACHINE or DISTRO to be Yocto project compliant",
                          run_on=[Classification.BBAPPEND])
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         self._core_constants = Constants(self._state.core_mod_ref)
 
         res = []

--- a/oelint_adv/rule_base/rule_var_src_uri.py
+++ b/oelint_adv/rule_base/rule_var_src_uri.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Variable
 from oelint_parser.cls_stash import Stash
@@ -207,7 +207,7 @@ class VarSRCUriOptions(Rule):
             'gitsm': {'usehead': ['branch', 'nobranch']},
         }
 
-    def __analyse(self, stash: Stash, item: Variable, _input: str, _index: int) -> List[Tuple[str, int, str]]:
+    def __analyse(self, stash: Stash, item: Variable, _input: str, _index: int) -> list[Rule.Finding]:
         _url = stash.GetScrComponents(_input)
         res = []
         if 'scheme' not in _url:
@@ -259,7 +259,7 @@ class VarSRCUriOptions(Rule):
                                         blockoffset=item.InFileLine)
         return res
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         items: List[Variable] = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
                                                   attribute=Variable.ATTR_VAR, attributeValue='SRC_URI')

--- a/oelint_adv/rule_base/rule_var_src_uri.py
+++ b/oelint_adv/rule_base/rule_var_src_uri.py
@@ -207,7 +207,7 @@ class VarSRCUriOptions(Rule):
             'gitsm': {'usehead': ['branch', 'nobranch']},
         }
 
-    def __analyse(self, stash: Stash, item: Variable, _input: str, _index: int) -> list[Rule.Finding]:
+    def __analyse(self, stash: Stash, item: Variable, _input: str, _index: int) -> List[Rule.Finding]:
         _url = stash.GetScrComponents(_input)
         res = []
         if 'scheme' not in _url:
@@ -259,7 +259,7 @@ class VarSRCUriOptions(Rule):
                                         blockoffset=item.InFileLine)
         return res
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         items: List[Variable] = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
                                                   attribute=Variable.ATTR_VAR, attributeValue='SRC_URI')

--- a/oelint_adv/rule_base/rule_var_src_uri_append.py
+++ b/oelint_adv/rule_base/rule_var_src_uri_append.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Variable, Inherit
 from oelint_parser.cls_stash import Stash
@@ -12,7 +12,7 @@ class VarSRCURIAppend(Rule):
                          severity='error',
                          message='<FOO>')
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         inherits = stash.GetItemsFor(filename=_file, classifier=Inherit.CLASSIFIER)
         if not inherits:

--- a/oelint_adv/rule_base/rule_var_src_uri_append.py
+++ b/oelint_adv/rule_base/rule_var_src_uri_append.py
@@ -12,7 +12,7 @@ class VarSRCURIAppend(Rule):
                          severity='error',
                          message='<FOO>')
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         inherits = stash.GetItemsFor(filename=_file, classifier=Inherit.CLASSIFIER)
         if not inherits:

--- a/oelint_adv/rule_base/rule_var_src_uri_checksum.py
+++ b/oelint_adv/rule_base/rule_var_src_uri_checksum.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import FlagAssignment, Item, Variable
 from oelint_parser.cls_stash import Stash
@@ -13,7 +13,7 @@ class VarSRCUriChecksum(Rule):
                          severity='error',
                          message='<FOO>')
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         items: List[Item] = stash.GetItemsFor(filename=_file,
                                               classifier=[FlagAssignment.CLASSIFIER, Variable.CLASSIFIER],

--- a/oelint_adv/rule_base/rule_var_src_uri_checksum.py
+++ b/oelint_adv/rule_base/rule_var_src_uri_checksum.py
@@ -13,7 +13,7 @@ class VarSRCUriChecksum(Rule):
                          severity='error',
                          message='<FOO>')
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         items: List[Item] = stash.GetItemsFor(filename=_file,
                                               classifier=[FlagAssignment.CLASSIFIER, Variable.CLASSIFIER],

--- a/oelint_adv/rule_base/rule_var_src_uri_domains.py
+++ b/oelint_adv/rule_base/rule_var_src_uri_domains.py
@@ -18,7 +18,7 @@ class VarSRCUriOptions(Rule):
                          severity='warning',
                          message='Recipe is pulling from different domains, this will likely cause issues')
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         items: List[Variable] = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
                                                   attribute=Variable.ATTR_VAR, attributeValue='SRC_URI')

--- a/oelint_adv/rule_base/rule_var_src_uri_domains.py
+++ b/oelint_adv/rule_base/rule_var_src_uri_domains.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Variable
 from oelint_parser.cls_stash import Stash
@@ -18,7 +18,7 @@ class VarSRCUriOptions(Rule):
                          severity='warning',
                          message='Recipe is pulling from different domains, this will likely cause issues')
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         items: List[Variable] = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
                                                   attribute=Variable.ATTR_VAR, attributeValue='SRC_URI')

--- a/oelint_adv/rule_base/rule_var_src_uri_file.py
+++ b/oelint_adv/rule_base/rule_var_src_uri_file.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Variable
 from oelint_parser.cls_stash import Stash
@@ -13,7 +13,7 @@ class VarSRCUriFirstFile(Rule):
                          severity='warning',
                          message='First item of SRC_URI should not be a file:// fetcher, if multiple fetcher are used')
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         items: List[Variable] = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
                                                   attribute=Variable.ATTR_VAR, attributeValue='SRC_URI')

--- a/oelint_adv/rule_base/rule_var_src_uri_file.py
+++ b/oelint_adv/rule_base/rule_var_src_uri_file.py
@@ -13,7 +13,7 @@ class VarSRCUriFirstFile(Rule):
                          severity='warning',
                          message='First item of SRC_URI should not be a file:// fetcher, if multiple fetcher are used')
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         items: List[Variable] = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
                                                   attribute=Variable.ATTR_VAR, attributeValue='SRC_URI')

--- a/oelint_adv/rule_base/rule_var_src_uri_gittag.py
+++ b/oelint_adv/rule_base/rule_var_src_uri_gittag.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Variable
 from oelint_parser.cls_stash import Stash
@@ -14,7 +14,7 @@ class VarSRCUriGitTag(Rule):
                          message="'tag' in SRC_URI-options leads to not-reproducible builds as git-tags can move around. Use explicit SRCREV",
                          valid_till_release="whinlatter")
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         items: List[Variable] = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
                                                   attribute=Variable.ATTR_VAR, attributeValue='SRC_URI')

--- a/oelint_adv/rule_base/rule_var_src_uri_gittag.py
+++ b/oelint_adv/rule_base/rule_var_src_uri_gittag.py
@@ -14,7 +14,7 @@ class VarSRCUriGitTag(Rule):
                          message="'tag' in SRC_URI-options leads to not-reproducible builds as git-tags can move around. Use explicit SRCREV",
                          valid_till_release="whinlatter")
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         items: List[Variable] = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
                                                   attribute=Variable.ATTR_VAR, attributeValue='SRC_URI')

--- a/oelint_adv/rule_base/rule_var_src_uri_srcrev_checksum.py
+++ b/oelint_adv/rule_base/rule_var_src_uri_srcrev_checksum.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Variable, FlagAssignment
 from oelint_parser.cls_stash import Stash
@@ -13,7 +13,7 @@ class VarSRCURIMutualExItems(Rule):
                          severity='error',
                          message="'SRCREV' and a checksum are defined for the same item - only one is applicable")
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         _srcuri: List[Variable] = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
                                                     attribute=Variable.ATTR_VAR, attributeValue='SRC_URI')

--- a/oelint_adv/rule_base/rule_var_src_uri_srcrev_checksum.py
+++ b/oelint_adv/rule_base/rule_var_src_uri_srcrev_checksum.py
@@ -13,7 +13,7 @@ class VarSRCURIMutualExItems(Rule):
                          severity='error',
                          message="'SRCREV' and a checksum are defined for the same item - only one is applicable")
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         _srcuri: List[Variable] = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
                                                     attribute=Variable.ATTR_VAR, attributeValue='SRC_URI')

--- a/oelint_adv/rule_base/rule_var_src_uri_srcrevtag.py
+++ b/oelint_adv/rule_base/rule_var_src_uri_srcrevtag.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Variable
 from oelint_parser.cls_stash import Stash
@@ -14,7 +14,7 @@ class VarSRCUriSRCREVTag(Rule):
                          message="'tag' in SRC_URI and a SRCREV for the same component doesn't compute",
                          valid_till_release="whinlatter")
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         items: List[Variable] = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
                                                   attribute=Variable.ATTR_VAR, attributeValue='SRC_URI')

--- a/oelint_adv/rule_base/rule_var_src_uri_srcrevtag.py
+++ b/oelint_adv/rule_base/rule_var_src_uri_srcrevtag.py
@@ -14,7 +14,7 @@ class VarSRCUriSRCREVTag(Rule):
                          message="'tag' in SRC_URI and a SRCREV for the same component doesn't compute",
                          valid_till_release="whinlatter")
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         items: List[Variable] = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
                                                   attribute=Variable.ATTR_VAR, attributeValue='SRC_URI')

--- a/oelint_adv/rule_base/rule_var_src_uri_wildcard.py
+++ b/oelint_adv/rule_base/rule_var_src_uri_wildcard.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Variable
 from oelint_parser.cls_stash import Stash
@@ -13,7 +13,7 @@ class VarSRCURIWildcard(Rule):
                          severity='error',
                          message="'SRC_URI' should not contain any wildcards")
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         _items: List[Variable] = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
                                                    attribute=Variable.ATTR_VAR, attributeValue='SRC_URI')

--- a/oelint_adv/rule_base/rule_var_src_uri_wildcard.py
+++ b/oelint_adv/rule_base/rule_var_src_uri_wildcard.py
@@ -13,7 +13,7 @@ class VarSRCURIWildcard(Rule):
                          severity='error',
                          message="'SRC_URI' should not contain any wildcards")
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         _items: List[Variable] = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
                                                    attribute=Variable.ATTR_VAR, attributeValue='SRC_URI')

--- a/oelint_adv/rule_base/rule_var_summary_80chars.py
+++ b/oelint_adv/rule_base/rule_var_summary_80chars.py
@@ -12,7 +12,7 @@ class VarSummary80Chars(Rule):
                          severity='warning',
                          message="'SUMMARY' should not be longer than 80 characters")
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         items: List[Variable] = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
                                                   attribute=Variable.ATTR_VAR, attributeValue='SUMMARY')

--- a/oelint_adv/rule_base/rule_var_summary_80chars.py
+++ b/oelint_adv/rule_base/rule_var_summary_80chars.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Variable
 from oelint_parser.cls_stash import Stash
@@ -12,7 +12,7 @@ class VarSummary80Chars(Rule):
                          severity='warning',
                          message="'SUMMARY' should not be longer than 80 characters")
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         items: List[Variable] = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
                                                   attribute=Variable.ATTR_VAR, attributeValue='SUMMARY')

--- a/oelint_adv/rule_base/rule_var_summary_linebreaks.py
+++ b/oelint_adv/rule_base/rule_var_summary_linebreaks.py
@@ -12,7 +12,7 @@ class VarSummaryLinebreaks(Rule):
                          severity='warning',
                          message="'SUMMARY' should not contain line breaks")
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         items: List[Variable] = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
                                                   attribute=Variable.ATTR_VAR, attributeValue='SUMMARY')

--- a/oelint_adv/rule_base/rule_var_summary_linebreaks.py
+++ b/oelint_adv/rule_base/rule_var_summary_linebreaks.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Variable
 from oelint_parser.cls_stash import Stash
@@ -12,7 +12,7 @@ class VarSummaryLinebreaks(Rule):
                          severity='warning',
                          message="'SUMMARY' should not contain line breaks")
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         items: List[Variable] = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
                                                   attribute=Variable.ATTR_VAR, attributeValue='SUMMARY')

--- a/oelint_adv/rule_base/rule_var_trailslash.py
+++ b/oelint_adv/rule_base/rule_var_trailslash.py
@@ -12,7 +12,7 @@ class VarTrailingSlash(Rule):
                          severity='error',
                          message="'{a}' must not end with a '/'")
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         items: List[Variable] = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
                                                   attribute=Variable.ATTR_VAR, attributeValue=['S', 'B', 'T', 'D'])

--- a/oelint_adv/rule_base/rule_var_trailslash.py
+++ b/oelint_adv/rule_base/rule_var_trailslash.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Variable
 from oelint_parser.cls_stash import Stash
@@ -12,7 +12,7 @@ class VarTrailingSlash(Rule):
                          severity='error',
                          message="'{a}' must not end with a '/'")
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         items: List[Variable] = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
                                                   attribute=Variable.ATTR_VAR, attributeValue=['S', 'B', 'T', 'D'])

--- a/oelint_adv/rule_base/rule_vars_bbclassextends.py
+++ b/oelint_adv/rule_base/rule_vars_bbclassextends.py
@@ -13,7 +13,7 @@ class VarBbclassextend(Rule):
                          run_on=[Classification.RECIPE],
                          message='BBCLASSEXTEND should be set if possible')
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         if stash.IsPackageGroup(_file) or stash.IsImage(_file) or _file in stash.GetConfFiles():
             return []
         res = []

--- a/oelint_adv/rule_base/rule_vars_bbclassextends.py
+++ b/oelint_adv/rule_base/rule_vars_bbclassextends.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Inherit, Variable
 from oelint_parser.cls_stash import Stash
@@ -13,7 +13,7 @@ class VarBbclassextend(Rule):
                          run_on=[Classification.RECIPE],
                          message='BBCLASSEXTEND should be set if possible')
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         if stash.IsPackageGroup(_file) or stash.IsImage(_file) or _file in stash.GetConfFiles():
             return []
         res = []

--- a/oelint_adv/rule_base/rule_vars_distroconf.py
+++ b/oelint_adv/rule_base/rule_vars_distroconf.py
@@ -1,5 +1,5 @@
 import fnmatch
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Variable
 from oelint_parser.cls_stash import Stash
@@ -29,7 +29,7 @@ class VarsDistroConf(Rule):
                          message='{var} should not be set as part of a distro configuration',
                          appendix=self.needles)
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         items: List[Variable] = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
                                                   attribute=Variable.ATTR_VAR)

--- a/oelint_adv/rule_base/rule_vars_distroconf.py
+++ b/oelint_adv/rule_base/rule_vars_distroconf.py
@@ -29,7 +29,7 @@ class VarsDistroConf(Rule):
                          message='{var} should not be set as part of a distro configuration',
                          appendix=self.needles)
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         items: List[Variable] = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
                                                   attribute=Variable.ATTR_VAR)

--- a/oelint_adv/rule_base/rule_vars_doublesemicolon.py
+++ b/oelint_adv/rule_base/rule_vars_doublesemicolon.py
@@ -23,7 +23,7 @@ class VarsDoubleSemicolon(Rule):
                 res.append(i)
         return res
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         for i in self.__getMatches(_file, stash):
             res += self.finding(i.Origin, i.InFileLine)

--- a/oelint_adv/rule_base/rule_vars_doublesemicolon.py
+++ b/oelint_adv/rule_base/rule_vars_doublesemicolon.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Variable
 from oelint_parser.cls_stash import Stash
@@ -23,7 +23,7 @@ class VarsDoubleSemicolon(Rule):
                 res.append(i)
         return res
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         for i in self.__getMatches(_file, stash):
             res += self.finding(i.Origin, i.InFileLine)

--- a/oelint_adv/rule_base/rule_vars_downloadfilename.py
+++ b/oelint_adv/rule_base/rule_vars_downloadfilename.py
@@ -12,7 +12,7 @@ class VarsDownloadfilename(Rule):
                          severity='warning',
                          message="Fetcher does create a download artifact without 'PV' in the filename")
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         items: List[Variable] = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
                                                   attribute=Variable.ATTR_VAR, attributeValue='SRC_URI')

--- a/oelint_adv/rule_base/rule_vars_downloadfilename.py
+++ b/oelint_adv/rule_base/rule_vars_downloadfilename.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Variable
 from oelint_parser.cls_stash import Stash
@@ -12,7 +12,7 @@ class VarsDownloadfilename(Rule):
                          severity='warning',
                          message="Fetcher does create a download artifact without 'PV' in the filename")
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         items: List[Variable] = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
                                                   attribute=Variable.ATTR_VAR, attributeValue='SRC_URI')

--- a/oelint_adv/rule_base/rule_vars_filessetting.py
+++ b/oelint_adv/rule_base/rule_vars_filessetting.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Variable
 from oelint_parser.cls_stash import Stash
@@ -19,7 +19,7 @@ class VarUnneededFilesSetting(Rule):
                                 needle: str,
                                 msg: str,
                                 appendix: str,
-                                onappendonly: bool = False) -> List[Tuple[str, int, str]]:
+                                onappendonly: bool = False) -> list[Rule.Finding]:
         res = []
         for i in _files:
             if variable_ in i.SubItems and 'remove' not in i.SubItems and needle in i.VarValue:  # pragma: no cover
@@ -28,7 +28,7 @@ class VarUnneededFilesSetting(Rule):
                                         override_msg=msg, appendix=appendix)
         return res
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         _all_files = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
                                        attribute=Variable.ATTR_VAR, attributeValue='FILES')

--- a/oelint_adv/rule_base/rule_vars_filessetting.py
+++ b/oelint_adv/rule_base/rule_vars_filessetting.py
@@ -19,7 +19,7 @@ class VarUnneededFilesSetting(Rule):
                                 needle: str,
                                 msg: str,
                                 appendix: str,
-                                onappendonly: bool = False) -> list[Rule.Finding]:
+                                onappendonly: bool = False) -> List[Rule.Finding]:
         res = []
         for i in _files:
             if variable_ in i.SubItems and 'remove' not in i.SubItems and needle in i.VarValue:  # pragma: no cover
@@ -28,7 +28,7 @@ class VarUnneededFilesSetting(Rule):
                                         override_msg=msg, appendix=appendix)
         return res
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         _all_files = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
                                        attribute=Variable.ATTR_VAR, attributeValue='FILES')

--- a/oelint_adv/rule_base/rule_vars_improperinherit.py
+++ b/oelint_adv/rule_base/rule_vars_improperinherit.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Inherit
 from oelint_parser.cls_stash import Stash
@@ -14,7 +14,7 @@ class VarImproperInherit(Rule):
                          severity='error',
                          message="'{inherit}' is not a proper bbclass name")
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         items: list[Inherit] = stash.GetItemsFor(
             filename=_file, classifier=Inherit.CLASSIFIER)

--- a/oelint_adv/rule_base/rule_vars_improperinherit.py
+++ b/oelint_adv/rule_base/rule_vars_improperinherit.py
@@ -14,7 +14,7 @@ class VarImproperInherit(Rule):
                          severity='error',
                          message="'{inherit}' is not a proper bbclass name")
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         items: list[Inherit] = stash.GetItemsFor(
             filename=_file, classifier=Inherit.CLASSIFIER)

--- a/oelint_adv/rule_base/rule_vars_inapp_class_override.py
+++ b/oelint_adv/rule_base/rule_vars_inapp_class_override.py
@@ -13,7 +13,7 @@ class VarsInappClassOverride(Rule):
                          run_on=[Classification.RECIPE],
                          message='{var} is using {override}, but the recipe does not set {class_} in BBCLASSEXTEND or inherits the class {class_}')
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         inherits = set()
         for item in stash.GetItemsFor(filename=_file, classifier=Inherit.CLASSIFIER):

--- a/oelint_adv/rule_base/rule_vars_inapp_class_override.py
+++ b/oelint_adv/rule_base/rule_vars_inapp_class_override.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Variable, Inherit, Function
 from oelint_parser.cls_stash import Stash
@@ -13,7 +13,7 @@ class VarsInappClassOverride(Rule):
                          run_on=[Classification.RECIPE],
                          message='{var} is using {override}, but the recipe does not set {class_} in BBCLASSEXTEND or inherits the class {class_}')
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         inherits = set()
         for item in stash.GetItemsFor(filename=_file, classifier=Inherit.CLASSIFIER):

--- a/oelint_adv/rule_base/rule_vars_inherit.py
+++ b/oelint_adv/rule_base/rule_vars_inherit.py
@@ -14,7 +14,7 @@ class VarInherit(Rule):
                          appendix=['inherit', 'inherit_defer'],
                          valid_from_release='scarthgap')
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         items: List[Inherit] = stash.GetItemsFor(filename=_file, classifier=Inherit.CLASSIFIER)
         for i in items:

--- a/oelint_adv/rule_base/rule_vars_inherit.py
+++ b/oelint_adv/rule_base/rule_vars_inherit.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Inherit
 from oelint_parser.cls_stash import Stash
@@ -14,7 +14,7 @@ class VarInherit(Rule):
                          appendix=['inherit', 'inherit_defer'],
                          valid_from_release='scarthgap')
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         items: List[Inherit] = stash.GetItemsFor(filename=_file, classifier=Inherit.CLASSIFIER)
         for i in items:

--- a/oelint_adv/rule_base/rule_vars_inherit_devtool.py
+++ b/oelint_adv/rule_base/rule_vars_inherit_devtool.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Inherit
 from oelint_parser.cls_stash import Stash
@@ -14,7 +14,7 @@ class VarInheritDevtool(Rule):
                          appendix=['native', 'nativesdk', 'cross'],
                          valid_from_release='scarthgap')
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         items: List[Inherit] = stash.GetItemsFor(filename=_file, classifier=Inherit.CLASSIFIER)
         for i in items:

--- a/oelint_adv/rule_base/rule_vars_inherit_devtool.py
+++ b/oelint_adv/rule_base/rule_vars_inherit_devtool.py
@@ -14,7 +14,7 @@ class VarInheritDevtool(Rule):
                          appendix=['native', 'nativesdk', 'cross'],
                          valid_from_release='scarthgap')
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         items: List[Inherit] = stash.GetItemsFor(filename=_file, classifier=Inherit.CLASSIFIER)
         for i in items:

--- a/oelint_adv/rule_base/rule_vars_inherit_last.py
+++ b/oelint_adv/rule_base/rule_vars_inherit_last.py
@@ -18,7 +18,7 @@ class VarInheritLast(Rule):
                          message='{VAR} needs to be inherited last',
                          appendix=self._needles)
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         items: List[Inherit] = stash.GetItemsFor(filename=_file, classifier=Inherit.CLASSIFIER)
         _findings = []

--- a/oelint_adv/rule_base/rule_vars_inherit_last.py
+++ b/oelint_adv/rule_base/rule_vars_inherit_last.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Inherit
 from oelint_parser.cls_stash import Stash
@@ -18,7 +18,7 @@ class VarInheritLast(Rule):
                          message='{VAR} needs to be inherited last',
                          appendix=self._needles)
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         items: List[Inherit] = stash.GetItemsFor(filename=_file, classifier=Inherit.CLASSIFIER)
         _findings = []

--- a/oelint_adv/rule_base/rule_vars_layerconf.py
+++ b/oelint_adv/rule_base/rule_vars_layerconf.py
@@ -1,5 +1,5 @@
 import fnmatch
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Variable
 from oelint_parser.cls_stash import Stash
@@ -30,7 +30,7 @@ class VarsLayerConf(Rule):
                          run_on=[Classification.LAYERCONF],
                          message='{var} should not be set as part of a layer configuration')
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         items: List[Variable] = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
                                                   attribute=Variable.ATTR_VAR)

--- a/oelint_adv/rule_base/rule_vars_layerconf.py
+++ b/oelint_adv/rule_base/rule_vars_layerconf.py
@@ -30,7 +30,7 @@ class VarsLayerConf(Rule):
                          run_on=[Classification.LAYERCONF],
                          message='{var} should not be set as part of a layer configuration')
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         items: List[Variable] = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
                                                   attribute=Variable.ATTR_VAR)

--- a/oelint_adv/rule_base/rule_vars_listappend.py
+++ b/oelint_adv/rule_base/rule_vars_listappend.py
@@ -27,7 +27,7 @@ class VarListAppend(Rule):
                 res_pre.append(i)
         return (res_app, res_pre)
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         res_app, res_pre = self.__getMatches(_file, stash)
         for i in res_app:

--- a/oelint_adv/rule_base/rule_vars_listappend.py
+++ b/oelint_adv/rule_base/rule_vars_listappend.py
@@ -27,7 +27,7 @@ class VarListAppend(Rule):
                 res_pre.append(i)
         return (res_app, res_pre)
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         res_app, res_pre = self.__getMatches(_file, stash)
         for i in res_app:

--- a/oelint_adv/rule_base/rule_vars_machineconf.py
+++ b/oelint_adv/rule_base/rule_vars_machineconf.py
@@ -27,7 +27,7 @@ class VarsMachineConf(Rule):
                          run_on=[Classification.MACHINECONF],
                          appendix=self.needles)
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         items: List[Variable] = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
                                                   attribute=Variable.ATTR_VAR)

--- a/oelint_adv/rule_base/rule_vars_machineconf.py
+++ b/oelint_adv/rule_base/rule_vars_machineconf.py
@@ -1,5 +1,5 @@
 import fnmatch
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Variable
 from oelint_parser.cls_stash import Stash
@@ -27,7 +27,7 @@ class VarsMachineConf(Rule):
                          run_on=[Classification.MACHINECONF],
                          appendix=self.needles)
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         items: List[Variable] = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
                                                   attribute=Variable.ATTR_VAR)

--- a/oelint_adv/rule_base/rule_vars_mandatory_exists.py
+++ b/oelint_adv/rule_base/rule_vars_mandatory_exists.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Inherit, Variable
 from oelint_parser.cls_stash import Stash
@@ -15,7 +15,7 @@ class VarMandatoryExists(Rule):
                          run_on=[Classification.RECIPE],
                          appendix=CONSTANTS.GetByPath('variables/mandatory'))
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         _is_pkg_group = stash.IsPackageGroup(_file)
         _is_image = stash.IsImage(_file)

--- a/oelint_adv/rule_base/rule_vars_mandatory_exists.py
+++ b/oelint_adv/rule_base/rule_vars_mandatory_exists.py
@@ -15,7 +15,7 @@ class VarMandatoryExists(Rule):
                          run_on=[Classification.RECIPE],
                          appendix=CONSTANTS.GetByPath('variables/mandatory'))
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         _is_pkg_group = stash.IsPackageGroup(_file)
         _is_image = stash.IsImage(_file)

--- a/oelint_adv/rule_base/rule_vars_multiinclude.py
+++ b/oelint_adv/rule_base/rule_vars_multiinclude.py
@@ -13,7 +13,7 @@ class VarMultiInclude(Rule):
                          severity='warning',
                          message="'{INC}' is included multiple times")
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         items: List[Include] = stash.GetItemsFor(filename=_file, classifier=Include.CLASSIFIER)
         _map = {}

--- a/oelint_adv/rule_base/rule_vars_multiinclude.py
+++ b/oelint_adv/rule_base/rule_vars_multiinclude.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Include
 from oelint_parser.cls_stash import Stash
@@ -13,7 +13,7 @@ class VarMultiInclude(Rule):
                          severity='warning',
                          message="'{INC}' is included multiple times")
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         items: List[Include] = stash.GetItemsFor(filename=_file, classifier=Include.CLASSIFIER)
         _map = {}

--- a/oelint_adv/rule_base/rule_vars_multiinherit.py
+++ b/oelint_adv/rule_base/rule_vars_multiinherit.py
@@ -12,7 +12,7 @@ class VarMultiInherit(Rule):
                          severity='warning',
                          message="'{inherit}' is included multiple times")
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         items: List[Inherit] = stash.GetItemsFor(filename=_file, classifier=Inherit.CLASSIFIER)
         keys = []

--- a/oelint_adv/rule_base/rule_vars_multiinherit.py
+++ b/oelint_adv/rule_base/rule_vars_multiinherit.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Inherit
 from oelint_parser.cls_stash import Stash
@@ -12,7 +12,7 @@ class VarMultiInherit(Rule):
                          severity='warning',
                          message="'{inherit}' is included multiple times")
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         items: List[Inherit] = stash.GetItemsFor(filename=_file, classifier=Inherit.CLASSIFIER)
         keys = []

--- a/oelint_adv/rule_base/rule_vars_native_filename.py
+++ b/oelint_adv/rule_base/rule_vars_native_filename.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Inherit
 from oelint_parser.cls_stash import Stash
@@ -13,7 +13,7 @@ class VarNativeFilename(Rule):
                          run_on=[Classification.BBAPPEND, Classification.RECIPE],
                          message="native-recipe-files should include '-native' in file name")
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         items: List[Inherit] = [x for x in stash.GetItemsFor(
             filename=_file, classifier=Inherit.CLASSIFIER) if 'native' in x.get_items()]

--- a/oelint_adv/rule_base/rule_vars_native_filename.py
+++ b/oelint_adv/rule_base/rule_vars_native_filename.py
@@ -13,7 +13,7 @@ class VarNativeFilename(Rule):
                          run_on=[Classification.BBAPPEND, Classification.RECIPE],
                          message="native-recipe-files should include '-native' in file name")
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         items: List[Inherit] = [x for x in stash.GetItemsFor(
             filename=_file, classifier=Inherit.CLASSIFIER) if 'native' in x.get_items()]

--- a/oelint_adv/rule_base/rule_vars_nativesdk_filename.py
+++ b/oelint_adv/rule_base/rule_vars_nativesdk_filename.py
@@ -13,7 +13,7 @@ class VarNativeSDKFilename(Rule):
                          run_on=[Classification.BBAPPEND, Classification.RECIPE],
                          message="nativesdk-recipe-files should include 'nativesdk-' in file name")
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         items: List[Inherit] = [x for x in
                                 stash.GetItemsFor(filename=_file, classifier=Inherit.CLASSIFIER)

--- a/oelint_adv/rule_base/rule_vars_nativesdk_filename.py
+++ b/oelint_adv/rule_base/rule_vars_nativesdk_filename.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Inherit
 from oelint_parser.cls_stash import Stash
@@ -13,7 +13,7 @@ class VarNativeSDKFilename(Rule):
                          run_on=[Classification.BBAPPEND, Classification.RECIPE],
                          message="nativesdk-recipe-files should include 'nativesdk-' in file name")
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         items: List[Inherit] = [x for x in
                                 stash.GetItemsFor(filename=_file, classifier=Inherit.CLASSIFIER)

--- a/oelint_adv/rule_base/rule_vars_order.py
+++ b/oelint_adv/rule_base/rule_vars_order.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Variable
 from oelint_parser.cls_stash import Stash
@@ -17,7 +17,7 @@ class VarsOrder(Rule):
     def __cleanname(self, _input: str) -> str:
         return _input.replace('$', '').replace('{', '').replace('}', '')
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         _files = {item.Origin for item in stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER)}
         for _single_file in _files:

--- a/oelint_adv/rule_base/rule_vars_order.py
+++ b/oelint_adv/rule_base/rule_vars_order.py
@@ -17,7 +17,7 @@ class VarsOrder(Rule):
     def __cleanname(self, _input: str) -> str:
         return _input.replace('$', '').replace('{', '').replace('}', '')
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         _files = {item.Origin for item in stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER)}
         for _single_file in _files:

--- a/oelint_adv/rule_base/rule_vars_outofcontext.py
+++ b/oelint_adv/rule_base/rule_vars_outofcontext.py
@@ -14,7 +14,7 @@ class VarOutOfContext(Rule):
                          message='{var} should be only set in {context}')
 
     def _check(self,
-               results: list[Rule.Finding],
+               results: List[Rule.Finding],
                items: List[Item],
                valid_context: List[Classification],
                var_desc: str = '',
@@ -40,7 +40,7 @@ class VarOutOfContext(Rule):
                        if x in CONSTANTS.ImagesClasses)
         return res
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
 
         for constants, valid_context in [

--- a/oelint_adv/rule_base/rule_vars_outofcontext.py
+++ b/oelint_adv/rule_base/rule_vars_outofcontext.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import FunctionExports, Inherit, Item, Variable
 from oelint_parser.cls_stash import Stash
@@ -14,7 +14,7 @@ class VarOutOfContext(Rule):
                          message='{var} should be only set in {context}')
 
     def _check(self,
-               results: List[Tuple[str, int, str]],
+               results: list[Rule.Finding],
                items: List[Item],
                valid_context: List[Classification],
                var_desc: str = '',
@@ -40,7 +40,7 @@ class VarOutOfContext(Rule):
                        if x in CONSTANTS.ImagesClasses)
         return res
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
 
         for constants, valid_context in [

--- a/oelint_adv/rule_base/rule_vars_pathhardcode.py
+++ b/oelint_adv/rule_base/rule_vars_pathhardcode.py
@@ -1,6 +1,6 @@
 from collections import OrderedDict
 from re import escape
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Export, Function, FunctionExports, Item, PythonBlock, Variable
 from oelint_parser.cls_stash import Stash
@@ -42,7 +42,7 @@ class VarsPathHardcode(Rule):
             self._map.move_to_end('/lib')
         return super().check_release_range(release_range)
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         items: List[Item] = stash.GetItemsFor(filename=_file,
                                               classifier=[Variable.CLASSIFIER, Export.CLASSIFIER,

--- a/oelint_adv/rule_base/rule_vars_pathhardcode.py
+++ b/oelint_adv/rule_base/rule_vars_pathhardcode.py
@@ -42,7 +42,7 @@ class VarsPathHardcode(Rule):
             self._map.move_to_end('/lib')
         return super().check_release_range(release_range)
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         items: List[Item] = stash.GetItemsFor(filename=_file,
                                               classifier=[Variable.CLASSIFIER, Export.CLASSIFIER,

--- a/oelint_adv/rule_base/rule_vars_suggested.py
+++ b/oelint_adv/rule_base/rule_vars_suggested.py
@@ -15,7 +15,7 @@ class VarSuggestedExists(Rule):
                          run_on=[Classification.RECIPE],
                          appendix=CONSTANTS.GetByPath('variables/suggested'))
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         _is_pkg_group = stash.IsPackageGroup(_file)
         _is_image = stash.IsImage(_file)

--- a/oelint_adv/rule_base/rule_vars_suggested.py
+++ b/oelint_adv/rule_base/rule_vars_suggested.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Inherit, Variable
 from oelint_parser.cls_stash import Stash
@@ -15,7 +15,7 @@ class VarSuggestedExists(Rule):
                          run_on=[Classification.RECIPE],
                          appendix=CONSTANTS.GetByPath('variables/suggested'))
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         _is_pkg_group = stash.IsPackageGroup(_file)
         _is_image = stash.IsImage(_file)

--- a/oelint_adv/rule_base/rule_vars_unpackdir.py
+++ b/oelint_adv/rule_base/rule_vars_unpackdir.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Variable
 from oelint_parser.cls_stash import Stash
@@ -13,7 +13,7 @@ class VarRootfsPostprocessCommand(Rule):
                          valid_from_release='styhead',
                          message='Use ${UNPACKDIR} instead of ${WORKDIR}')
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         items: List[Variable] = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
                                                   attribute=Variable.ATTR_VAR, attributeValue=['S'])

--- a/oelint_adv/rule_base/rule_vars_unpackdir.py
+++ b/oelint_adv/rule_base/rule_vars_unpackdir.py
@@ -13,7 +13,7 @@ class VarRootfsPostprocessCommand(Rule):
                          valid_from_release='styhead',
                          message='Use ${UNPACKDIR} instead of ${WORKDIR}')
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         items: List[Variable] = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
                                                   attribute=Variable.ATTR_VAR, attributeValue=['S'])

--- a/oelint_adv/rule_base/rule_vars_variable_override.py
+++ b/oelint_adv/rule_base/rule_vars_variable_override.py
@@ -13,7 +13,7 @@ class VarOverride(Rule):
                          severity='error',
                          message='<FOO>')
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         _all: List[Variable] = list(x for x in stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER))  # noqa: C400
         for v in {x.VarName for x in _all}:

--- a/oelint_adv/rule_base/rule_vars_variable_override.py
+++ b/oelint_adv/rule_base/rule_vars_variable_override.py
@@ -1,5 +1,5 @@
 import os
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Variable
 from oelint_parser.cls_stash import Stash
@@ -13,7 +13,7 @@ class VarOverride(Rule):
                          severity='error',
                          message='<FOO>')
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         _all: List[Variable] = list(x for x in stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER))  # noqa: C400
         for v in {x.VarName for x in _all}:

--- a/oelint_adv/rule_base/rule_vars_virtual.py
+++ b/oelint_adv/rule_base/rule_vars_virtual.py
@@ -12,7 +12,7 @@ class VarsVirtualProvDep(Rule):
                          severity='error',
                          message='{var} can not contain virtual/ items')
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         items: List[Variable] = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
                                                   attribute=Variable.ATTR_VAR, attributeValue=['RDEPENDS', 'RPROVIDES'])

--- a/oelint_adv/rule_base/rule_vars_virtual.py
+++ b/oelint_adv/rule_base/rule_vars_virtual.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Variable
 from oelint_parser.cls_stash import Stash
@@ -12,7 +12,7 @@ class VarsVirtualProvDep(Rule):
                          severity='error',
                          message='{var} can not contain virtual/ items')
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         items: List[Variable] = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
                                                   attribute=Variable.ATTR_VAR, attributeValue=['RDEPENDS', 'RPROVIDES'])

--- a/oelint_adv/rule_jetm/rule_var_depends_singleline.py
+++ b/oelint_adv/rule_jetm/rule_var_depends_singleline.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from oelint_parser.cls_item import Variable
 from oelint_parser.cls_stash import Stash
@@ -12,7 +12,7 @@ class VarDependsSingleLine(Rule):
                          severity='warning',
                          message='Each [R]DEPENDS entry should be put into a single line')
 
-    def check(self, _file: str, stash: Stash) -> List[Tuple[str, int, str]]:
+    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
         res = []
         items = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
                                   attribute=Variable.ATTR_VAR, attributeValue=['DEPENDS', 'RDEPENDS'])

--- a/oelint_adv/rule_jetm/rule_var_depends_singleline.py
+++ b/oelint_adv/rule_jetm/rule_var_depends_singleline.py
@@ -12,7 +12,7 @@ class VarDependsSingleLine(Rule):
                          severity='warning',
                          message='Each [R]DEPENDS entry should be put into a single line')
 
-    def check(self, _file: str, stash: Stash) -> list[Rule.Finding]:
+    def check(self, _file: str, stash: Stash) -> List[Rule.Finding]:
         res = []
         items = stash.GetItemsFor(filename=_file, classifier=Variable.CLASSIFIER,
                                   attribute=Variable.ATTR_VAR, attributeValue=['DEPENDS', 'RDEPENDS'])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,9 +51,6 @@ ignore = [
 exclude = [ "tests/*" ]
 statistics = false
 
-[tool.mypy]
-python_executable="../venv/bin/python"
-
 [project]
 name = "oelint_adv"
 requires-python = ">= 3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,9 @@ ignore = [
 exclude = [ "tests/*" ]
 statistics = false
 
+[tool.mypy]
+python_executable="../venv/bin/python"
+
 [project]
 name = "oelint_adv"
 requires-python = ">= 3.10"

--- a/tests/test_outputformat.py
+++ b/tests/test_outputformat.py
@@ -1,4 +1,9 @@
+import pytest  # noqa: I900
+
 from .base import TestBaseClass
+
+import hashlib
+import json
 
 # flake8: noqa S101 - n.a. for test files
 
@@ -46,3 +51,78 @@ class TestOutputFormat(TestBaseClass):
         assert '<testsuite id="oelint-adv" name="oelint-adv" tests="1" failures="0" errors="0" skipped="0">' in captured.err
         assert '<testcase name="oelint.run.passed"/>' in captured.err
         assert not captured.out
+
+    def test_output_gitlab_bad(self, capsys):
+        from oelint_adv.__main__ import run
+        from oelint_adv.outputformat import _OUTPUT_FORMATS
+
+        _args = self._create_args({'test.bb': 'A="1"'}, [
+                                  '--outputformat=gitlab-codequality'])
+        _issues, _ = run(_args)
+        capsys.readouterr()
+        _OUTPUT_FORMATS[_args.outputformat](_args, _issues)
+        captured = capsys.readouterr()
+
+        j = json.loads(captured.err)
+        assert isinstance(j, list)
+        [spacesassignment] = [x for x in j if x['check_name']
+                              == 'oelint.vars.spacesassignment']
+        assert spacesassignment is not None
+        self._verify_json_finding(spacesassignment,
+                                  check_name='oelint.vars.spacesassignment',
+                                  file='test.bb',
+                                  line=1,
+                                  severity_oelint='warning',
+                                  severity_gitlab='minor',
+                                  text='Suggest spaces around assignment')
+
+        assert not captured.out
+
+    @pytest.mark.parametrize('severity',
+                             [
+                                 ('info', 'info'),
+                                 ('warning', 'minor'),
+                                 ('error', 'critical')
+                             ],
+                             )
+    def test_output_gitlab_severity_conversion(self, capsys, severity):
+        from oelint_adv.__main__ import run
+        from oelint_adv.outputformat import OutputFormatGitlabCodequality
+
+        _args = self._create_args({'test.bb': 'A="1"'}, [])
+
+        _issues = [[["unused", 1, "unused", severity[0]], "unused"]]
+        OutputFormatGitlabCodequality(_args, _issues)
+        captured = capsys.readouterr()
+        j = json.loads(captured.err)
+        assert j[0]['severity'] == severity[1]
+
+        assert isinstance(j, list)
+
+    def test_output_gitlab_good(self, capsys):
+        from oelint_adv.__main__ import run
+        from oelint_adv.outputformat import _OUTPUT_FORMATS
+        _args = self._create_args({'test.bbappend': 'A = "1"\n'}, [
+                                  '--outputformat=gitlab-codequality',
+                                  '--suppress=oelint.vars.mispell',
+                                  '--suppress=oelint.vars.noncoreoverride'])
+        _issues, _ = run(_args)
+        capsys.readouterr()
+        _OUTPUT_FORMATS[_args.outputformat](_args, _issues)
+        captured = capsys.readouterr()
+        assert captured.err == "[]"
+        assert not captured.out
+
+    def _verify_json_finding(self, j: dict,
+                             check_name: str,
+                             file: str, line: int,
+                             severity_oelint: str, severity_gitlab: str,
+                             text: str):
+        assert j['check_name'] == check_name
+        assert j['severity'] == severity_gitlab
+        desc = j['description'].split(':', maxsplit=4)
+        assert desc[2] == severity_oelint
+        assert text in desc[4]
+        assert j['fingerprint'] == hashlib.sha256(j['description'].encode('utf-8')).hexdigest()
+        assert j['location']['path'].endswith(file)
+        assert line == j['location']['lines']['begin']


### PR DESCRIPTION
Implement the json-based `gitlab-codequality` output format.

[This format](https://docs.gitlab.com/ci/testing/code_quality/#code-quality-report-format) can be used to integrate the linter into GitLab pipelines and display the results as a "Code Quality" page.
This page provides a nice view of all findings, colors them according to their severity and provides links to the corresponding code locations.

This work required two changes in internal interfaces (see commit messages for details):
 - the finding data now contains the finding's `severity` in addition to the `id`, `file` and `location`. This is required for the `OutputFormat` to assign the correct severity to each entry without parsing it from the human-readable message.
 - the `OutputFormat` constructors declared the finding argument to be of a different type than what was actually used. This only affected readability.

# Pull request checklist

~## Bugfix~

~- [ ] A testcase was added to test the behavior~

## New feature

- [x] A testcase was added to test the behavior
- ~[ ] ``wiki-creator.py`` was run and a new wiki document was filled with information~
- ~[ ] New functions are documented with docstrings~
- [x] No debug code is left
- [x] README.md was updated to reflect the changes (check even if n.a.)
