### PR TITLE
fix: allow cp without ownership preservation

### DIFF
--- a/oelint_adv/rule_base/rule_tasks_no_cp.py
+++ b/oelint_adv/rule_base/rule_tasks_no_cp.py
@@ -22,7 +22,8 @@ class TaskInstallNoCp(Rule):
                     if line.strip().startswith('#'):
                         continue
                     if (RegexRpl.search(r'^\s*cp ', line) or RegexRpl.search(r'\s+cp ', line)) and not RegexRpl.search(
-                            r'\s*cp\s+(-R|-r)', line):
+                            r'\s*cp\s+(-R|-r)', line) and not RegexRpl.search(
+                                r'\s*cp\s+--no-preserve=ownership(?:\s|$)', line):
                         res += self.finding(item.Origin,
                                             item.InFileLine + lineindex, blockoffset=item.InFileLine)
         return res

--- a/tests/test_class_oelint_task_nocp.py
+++ b/tests/test_class_oelint_task_nocp.py
@@ -59,7 +59,15 @@ class TestClassOelintTaskNoCopy(TestBaseClass):
                                          }
                                          ''',
                                  },
-                             ],
+                                 {
+                                     'oelint_adv_test.bb':
+                                         '''
+                                         do_install_append() {
+                                             cp --no-preserve=ownership A B
+                                         }
+                                         ''',
+                                 },
+                                 ],
                              )
     def test_good(self, input_, id_, occurrence):
         self.check_for_id(self._create_args(input_), id_, occurrence)


### PR DESCRIPTION
## Summary

- exempt `cp --no-preserve=ownership` from `oelint.task.nocopy`
- add regression coverage for the documented safe install command

Fixes #931.

## Verification

- `PATH="$PWD/.venv/bin:$PATH" .venv/bin/pytest --no-cov -p no:cacheprovider -n 2 -q`
- `PATH="$PWD/.venv/bin:$PATH" COVERAGE_FILE=/dev/shm/oelint-coverage .venv/bin/pytest -q -n 2`
- `pre-commit run --files $(git ls-files)`
- `flake8 $(git ls-files '*.py')`
- `python -m build --sdist --wheel`
- installed-wheel `oelint-adv --help` smoke check

# Pull request checklist

## Bugfix

- [x] A testcase was added to test the behavior

## New feature

- [ ] A testcase was added to test the behavior
- [ ] ``wiki-creator.py`` was run and a new wiki document was filled with information
- [ ] New functions are documented with docstrings
- [ ] No debug code is left
- [ ] README.md was updated to reflect the changes (check even if n.a.)
