### PR TITLE
oelint_adv: add --layer-path for cross-layer require resolution

### DIFF
--- a/oelint_adv/__main__.py
+++ b/oelint_adv/__main__.py
@@ -84,6 +84,10 @@ def create_argparser() -> argparse.ArgumentParser:
                         help='Clear cache directory and exit')
     parser.add_argument('--extra-layer', nargs='*', action='extend',
                         default=['core'], help='Layer names of 3rd party layers to use')
+    parser.add_argument('--layer-path', nargs='*', action='extend', default=[],
+                        help='Extra layer root directories to search when resolving a '
+                             'require/include path, mirroring BBPATH. Opt-in; when unset '
+                             'a require is only searched in its own layer.')
     # Override the defaults with the values from the config file
     parser.set_defaults(**parse_configfile())
 

--- a/oelint_adv/core.py
+++ b/oelint_adv/core.py
@@ -337,7 +337,8 @@ def create_lib_arguments(files: List[str],
                          mode: str = 'fast',
                          cached: bool = False,
                          cachedir: str = __default_cache_dir,
-                         extra_layer: List[str] = None) -> argparse.Namespace:
+                         extra_layer: List[str] = None,
+                         layer_path: List[str] = None) -> argparse.Namespace:
     """Create runtime arguments in library mode
 
     Args:
@@ -362,6 +363,8 @@ def create_lib_arguments(files: List[str],
         cached (bool, optional): Use caching
         cachedir (str, optional): Path to cache directory,
         extra_layer (List[str], optional): Extra 3rd party layer to load data for
+        layer_path (List[str], optional): Extra layer root directories to search when
+            resolving a require/include path, mirroring BBPATH. Defaults to None.
 
     Returns:
         argparse.Namespace: runtime arguments
@@ -397,6 +400,9 @@ def create_lib_arguments(files: List[str],
                         help='Clear cache directory and exit')
     parser.add_argument('--extra-layer', nargs='*', action='extend',
                         default=['core'], help='Layer names of 3rd party layers to use')
+    parser.add_argument('--layer-path', nargs='*', action='extend', default=[],
+                        help='Extra layer root directories to search when resolving a '
+                             'require/include path, mirroring BBPATH')
     # Override the defaults with the values from the config file
     parser.set_defaults(**parse_configfile())
 
@@ -423,6 +429,7 @@ def create_lib_arguments(files: List[str],
         '--cached' if cached else '',
         f'--cachedir={cachedir}',
         *[f'--extra-layer={x}' for x in (extra_layer or ())],
+        *[f'--layer-path={x}' for x in (layer_path or ())],
         * files,
     ] if y != '']
 
@@ -456,6 +463,7 @@ def arguments_post(args: argparse.Namespace) -> argparse.Namespace:  # noqa: C90
         'customrules',
         'suppress',
         'extra_layer',
+        'layer_path',
         'hide',
     ]:
         try:

--- a/oelint_adv/rule_base/rule_file_include.py
+++ b/oelint_adv/rule_base/rule_file_include.py
@@ -18,7 +18,7 @@ class FileIncludeNotFound(Rule):
         for item in stash.GetItemsFor(filename=_file,
                                       classifier=Include.CLASSIFIER):
             if item.Statement == 'include':
-                _path = stash.ExpandTerm(_file, item.IncName)
+                _path = stash.ExpandTerm(_file, item.IncName, for_include=True)
                 if not stash.FindLocalOrLayer(_path, os.path.dirname(item.Origin)):
                     res += self.finding(item.Origin, item.InFileLine,
                                         self.Msg.replace('{FILE}', item.IncName))

--- a/oelint_adv/rule_base/rule_file_reqinc_norelpaths.py
+++ b/oelint_adv/rule_base/rule_file_reqinc_norelpaths.py
@@ -16,7 +16,7 @@ class FileReqIncNoRelPaths(Rule):
         res = []
         for item in stash.GetItemsFor(filename=_file,
                                       classifier=Include.CLASSIFIER):
-            _path = stash.ExpandTerm(_file, item.IncName)
+            _path = stash.ExpandTerm(_file, item.IncName, for_include=True)
             if '..' in _path.split('/'):
                 res += self.finding(item.Origin, item.InFileLine)
         return res

--- a/oelint_adv/rule_base/rule_file_require.py
+++ b/oelint_adv/rule_base/rule_file_require.py
@@ -18,7 +18,7 @@ class FileRequireNotFound(Rule):
         for item in stash.GetItemsFor(filename=_file,
                                       classifier=Include.CLASSIFIER):
             if item.Statement == 'require':
-                _path = stash.ExpandTerm(_file, item.IncName)
+                _path = stash.ExpandTerm(_file, item.IncName, for_include=True)
                 if not stash.FindLocalOrLayer(_path, os.path.dirname(item.Origin)):
                     res += self.finding(item.Origin, item.InFileLine,
                                         self.Msg.replace('{FILE}', item.IncName))

--- a/oelint_adv/tweaks.py
+++ b/oelint_adv/tweaks.py
@@ -127,5 +127,9 @@ class Tweaks:
         args.constantmods[0:0] = modlist
 
         setattr(args, '_release_range', _release_range)  # noqa: B010
-        args.state.additional_stash_args = getattr(args, '_stash_args', {})
+        _stash_args = dict(getattr(args, '_stash_args', {}))
+        _layer_path = getattr(args, 'layer_path', None)
+        if _layer_path:
+            _stash_args['layer_paths'] = _layer_path
+        args.state.additional_stash_args = _stash_args
         return args

--- a/tests/test_class_oelint_file_layerpath.py
+++ b/tests/test_class_oelint_file_layerpath.py
@@ -1,0 +1,100 @@
+import os
+import shutil
+import tempfile
+
+from .base import TestBaseClass
+
+
+# flake8: noqa S101 - n.a. for test files
+class TestClassOelintLayerPath(TestBaseClass):
+    """Cross-layer require resolution via the opt-in --layer-path flag.
+
+    A require in one layer can point at an include shipped by a sister layer
+    (as u-boot-fslc does in meta-freescale). bitbake resolves that against
+    BBPATH; oelint only searches the containing layer, so it reports a false
+    oelint.file.requirenotfound. --layer-path mirrors BBPATH to fix this.
+    """
+
+    def _make_layer_root(self, name):
+        _root = os.path.join(tempfile.mkdtemp(), name)
+        os.makedirs(os.path.join(_root, 'conf'), exist_ok=True)
+        with open(os.path.join(_root, 'conf', 'layer.conf'), 'w') as o:
+            o.write('# test layer\n')
+        self._extra_roots = getattr(self, '_extra_roots', [])
+        self._extra_roots.append(_root)
+        return _root
+
+    def _write(self, _root, relpath, content):
+        _path = os.path.join(_root, relpath)
+        os.makedirs(os.path.dirname(_path), exist_ok=True)
+        with open(_path, 'w') as o:
+            o.write(content)
+        return _path
+
+    def teardown_method(self):
+        super().teardown_method()
+        for _root in getattr(self, '_extra_roots', []):
+            shutil.rmtree(os.path.dirname(_root), ignore_errors=True)
+
+    def _consumer_recipe(self, require_line):
+        _consumer = self._make_layer_root('meta-consumer')
+        _recipe = self._write(
+            _consumer, 'recipes-foo/foo/foo_2025.01.bb',
+            'SUMMARY = "t"\nLICENSE = "MIT"\n{req}\n'.format(req=require_line))
+        return _consumer, _recipe
+
+    def _count_id(self, args, id_):
+        from oelint_adv.__main__ import run
+        _issues, _ = run(args)
+        return len([x[1] for x in _issues if ':{id}:'.format(id=id_) in x[1]])
+
+    def test_bad_without_layer_path(self):
+        # include lives only in the sister layer -> not found without --layer-path
+        _consumer, _recipe = self._consumer_recipe(
+            'require recipes-foo/foo/foo-common.inc')
+        _provider = self._make_layer_root('meta-provider')
+        self._write(_provider, 'recipes-foo/foo/foo-common.inc', 'VAR = "a"\n')
+
+        args = self._create_args_plain([_recipe])
+        assert self._count_id(args, 'oelint.file.requirenotfound') == 1
+
+    def test_good_with_layer_path(self):
+        # --layer-path at the provider layer resolves the include
+        _consumer, _recipe = self._consumer_recipe(
+            'require recipes-foo/foo/foo-common.inc')
+        _provider = self._make_layer_root('meta-provider')
+        self._write(_provider, 'recipes-foo/foo/foo-common.inc', 'VAR = "a"\n')
+
+        args = self._create_args_plain(
+            [_recipe], extraopts=['--layer-path={r}'.format(r=_provider)])
+        assert self._count_id(args, 'oelint.file.requirenotfound') == 0
+
+    def test_good_with_layer_path_pv_from_filename(self):
+        # ${PV} in the include name resolves to the filename version (2025.01),
+        # not the assigned PV -- needs for_include semantics to find the file.
+        _consumer, _recipe = self._consumer_recipe(
+            'require recipes-foo/foo/foo-common_${PV}.inc\n'
+            'PV = "2025.01+fslc+git${SRCPV}"')
+        _provider = self._make_layer_root('meta-provider')
+        self._write(_provider, 'recipes-foo/foo/foo-common_2025.01.inc',
+                    'VAR = "a"\n')
+
+        args = self._create_args_plain(
+            [_recipe], extraopts=['--layer-path={r}'.format(r=_provider)])
+        assert self._count_id(args, 'oelint.file.requirenotfound') == 0
+
+    def test_lib_arguments_layer_path(self):
+        # library entry point threads layer_path through like the CLI flag
+        from oelint_adv.core import create_lib_arguments
+        from oelint_adv.__main__ import run
+
+        _consumer, _recipe = self._consumer_recipe(
+            'require recipes-foo/foo/foo-common.inc')
+        _provider = self._make_layer_root('meta-provider')
+        self._write(_provider, 'recipes-foo/foo/foo-common.inc', 'VAR = "a"\n')
+
+        args = create_lib_arguments([_recipe], quiet=True, jobs=1,
+                                    layer_path=[_provider])
+        _issues, _ = run(args)
+        issues = [x[1] for x in _issues]
+        assert not any(':oelint.file.requirenotfound:' in x for x in issues)


### PR DESCRIPTION
## What

Add an opt-in `--layer-path` CLI flag (and a `layer_path` library argument)
that mirrors bitbake's `BBPATH`. The paths are threaded through to the
`Stash`, and the `require`/`include` rules expand include paths with
`for_include` semantics.

## Why

A `require`/`include` shipped by a sister layer previously raised a false
`oelint.file.requirenotfound`. With the layer paths configured, the file
resolves and the false positive is gone.

## Depends on

Needs the `layer_paths` / `for_include` support in `oelint-parser`
(https://github.com/priv-kweihmann/oelint-parser/pull/408). Merge that first.

## Notes

- Fully opt-in: no flag means unchanged behaviour.
- Added `tests/test_class_oelint_file_layerpath.py`.